### PR TITLE
Replace FTP URL for newlib with mirror

### DIFF
--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -74,7 +74,7 @@ function toolchain_install
         # Check if newlib sources are available, download it if needed
         if [ ! -f "$NEWLIB.tar.gz" ]; then
                 echo -e "Downloading $NEWLIB.tar.gz"
-                wget -c ftp://sources.redhat.com/pub/newlib/$NEWLIB.tar.gz || exit 0
+                wget -c ftp://sourceware.org/pub/newlib/$NEWLIB.tar.gz || exit 0
         fi;
 
         rm -rf build


### PR DESCRIPTION
sources.redhat.org FTP server no longer allows anonymous login, replace with mirror which does so that toolchain can be compiled