### PR TITLE
fix zlip, bzip2 and freetype building. other misc bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ toolchain/*.tar.gz
 toolchain/*.tar.bz2
 toolchain/*.tar.xz
 docs/
+toolchain/ext2fs-xenon
+toolchain/fat-xenon
+toolchain/libxtaf
+toolchain/libntfs
+toolchain/extds-xenon
+toolchain/extds-xenon

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ After installation of the toolchain, the following environment variables need to
 
 `DEVKITXENON` is dependencing on your chosen installation prefix location.
 
-```
-DEVKITXENON="/usr/local/xenon"
-PATH="$PATH:$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
+(it's recommended to add the below to your bashrc)
+
+```sh
+export DEVKITXENON=/usr/local/xenon
+PATH=$PATH:$DEVKITXENON/bin:$DEVKITXENON/usr/bin
 ```
 
-### Prefix
+### Prefix (only needed when DEVKITXENON not set)
 
 If you want to choose your own prefix, prepend it to the `./build-xenon-toolchain` invocation.
 
@@ -57,18 +59,9 @@ e.g. `PREFIX=/home/username/xenon ./build-xenon-toolchain toolchain`
 
 ### Installing toolchain
 
-```
-./build-xenon-toolchain toolchain
-```
-
-### Install libxenon library
-
-```
-./build-xenon-toolchain libxenon
-```
-
-### Install auxiliary libs
-
-```
-./build-xenon-toolchain libs
+```sh
+cd toolchain
+./build-xenon-toolchain toolchain # install toolchain
+./build-xenon-toolchain libxenon # install libxenon
+./build-xenon-toolchain libs # install libs (zlib, bzip, libpng, freetype2)
 ```

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ e.g. `PREFIX=/home/username/xenon ./build-xenon-toolchain toolchain`
 cd toolchain
 ./build-xenon-toolchain toolchain # install toolchain
 ./build-xenon-toolchain libxenon # install libxenon
-./build-xenon-toolchain libs # install libs (zlib, bzip, libpng, freetype2)
+./build-xenon-toolchain libs # install libs (zlib, bzip, libpng, freetype, sdl, sdl_image, sdl_mixer, sdl_ttf)
 ```

--- a/libxenon/drivers/iso9660/iso9660.c
+++ b/libxenon/drivers/iso9660/iso9660.c
@@ -63,7 +63,7 @@ static int percd_done;
 /* Joliet UCS is big endian */
 static void utf2ucs(char * ucs, const char * utf) {
 	int c;
-	
+
 	do {
 		c = *utf++;
 		if (c <= 0x7f) {
@@ -82,7 +82,7 @@ static void utf2ucs(char * ucs, const char * utf) {
 
 static void ucs2utfn(char * utf, const char * ucs, size_t len) {
 	int c;
-	
+
 	len = len / 2;
 	while (len) {
 		len--;
@@ -167,7 +167,7 @@ typedef struct filestruct_s
 static u32 ntohl_32(const void *data) {
 	const u8 *d = (const u8*)data;
 	return (d[0] << 24) | (d[1] << 16) | (d[2] << 8) | (d[3] << 0);
-} 
+}
 
 /* This seems kinda silly, but it's important since it allows us
    to do unaligned accesses on a buffer */
@@ -184,7 +184,7 @@ static u32 iso_733(const u8 *from) { return htohl_32(from); }
 
 
 /********************************************************************************/
-/* Low-level block cacheing routines. This implements a simple queue-based 
+/* Low-level block cacheing routines. This implements a simple queue-based
    LRU/MRU cacheing system. Whenever a block is requested, it will be placed
    on the MRU end of the queue. As more blocks are loaded than can fit in
    the cache, blocks are deleted from the LRU end. */
@@ -209,7 +209,7 @@ static unsigned int * cache_mutex;
 /* Clears all cache blocks */
 static void bclear_cache(cache_block_t **cache) {
 	int i;
-	
+
 	lock(cache_mutex);
 	for (i=0; i<NUM_CACHE_BLOCKS; i++)
 		cache[i]->sector = -1;
@@ -220,10 +220,10 @@ static void bclear_cache(cache_block_t **cache) {
 static void bgrad_cache(cache_block_t **cache, int block) {
 	int		i;
 	cache_block_t	*tmp;
-	
+
 	/* Don't try it with the end block */
 	if (block < 0 || block >= (NUM_CACHE_BLOCKS-1)) return;
-	
+
 	/* Make a copy and scoot everything down */
 	tmp = cache[block];
 	for (i=block; i<(NUM_CACHE_BLOCKS - 1); i++)
@@ -238,7 +238,7 @@ static void iso_break_all();
 static int bread_cache(cache_block_t **cache, u32 sector) {
 	int i, j, rv;
 
-	rv = -1;	
+	rv = -1;
 	lock(cache_mutex);
 
 	/* Look for a pre-existing cache block */
@@ -249,30 +249,30 @@ static int bread_cache(cache_block_t **cache, u32 sector) {
 			goto bread_exit;
 		}
 	}
-	
+
 	/* If not, look for an open cache slot; if we find one, use it */
 	for (i=0; i<NUM_CACHE_BLOCKS; i++) {
 		if (cache[i]->sector == -1) break;
 	}
-	
+
 	/* If we didn't find one, kick an LRU block out of cache */
 	if (i >= NUM_CACHE_BLOCKS) { i = 0; }
-	
+
 	/* Load the requested block */
 	j = iso9660_dev->readSectors(sector, 1, cache[i]->data);
 	if (j < 0) {
-		
+
 		if (j==DISKIO_ERROR_NO_MEDIA) {
 			unlock(cache_mutex);
 			iso_reset();
 		} else
 			dbglog(DBG_ERROR, "fs_iso9660: can't read_sectors for %d: %d\n", (unsigned int)sector, j);
-		
+
 		rv = -1;
 		goto bread_exit;
 	}
 	cache[i]->sector = sector;
-	
+
 	/* Move it to the most-recently-used position */
 	bgrad_cache(cache, i);
 	rv = NUM_CACHE_BLOCKS - 1;
@@ -318,10 +318,10 @@ static int init_percd() {
 	int		i, blk;
 
 	//dbglog(DBG_NOTICE, "fs_iso9660: disc change detected\n");
-	
+
 	/* Start off with no cached blocks and no open files*/
 	iso_reset();
-	
+
 	/* Check for joliet extensions */
 	joliet = 0;
 	for (i=1; i<=3; i++) {
@@ -336,7 +336,7 @@ static int init_percd() {
 
 	/* If that failed, go after standard/RockRidge ISO */
 	if (!joliet) {
-		/* Grab and check the volume descriptor */	
+		/* Grab and check the volume descriptor */
 		blk = biread(session_base + 16);
 		if (blk < 0) return i;
 		if (memcmp((char*)icache[blk]->data, "\01CD001", 6)) {
@@ -349,7 +349,7 @@ static int init_percd() {
 	memcpy(&root_dirent, icache[blk]->data+156, sizeof(iso_dirent_t));
 	root_extent = iso_733(root_dirent.extent);
 	root_size = iso_733(root_dirent.size);
-	
+
 	return 0;
 }
 
@@ -385,12 +385,12 @@ static int fncompare(const char *isofn, int isosize, const char *normalfn) {
 
 /* Locate an ISO9660 object in the given directory; this can be a directory or
    a file, it works fine for either one. Pass in:
-   
+
    fn:		object filename (relative to the passed directory)
    dir:		0 if looking for a file, 1 if looking for a dir
    dir_extent:	directory extent to start with
    dir_size:	directory size (in bytes)
-   
+
    It will return a pointer to a transient dirent buffer (i.e., don't
    expect this buffer to stay around much longer than the call itself).
  */
@@ -414,11 +414,11 @@ static iso_dirent_t *find_object(const char *fn, int dir, u32 dir_extent, u32 di
 	/* If this is a Joliet CD, then UCSify the name */
 	if (joliet)
 		utf2ucs(ucsname, fn);
-	
+
 	while (size_left > 0) {
 		c = biread(dir_extent);
 		if (c < 0) return NULL;
-		
+
 		for (i=0; i<2048 && i<size_left; ) {
 			/* Locate the current dirent */
 			de = (iso_dirent_t *)(icache[c]->data + i);
@@ -433,7 +433,7 @@ static iso_dirent_t *find_object(const char *fn, int dir, u32 dir_extent, u32 di
 			} else {
 				/* Assume no Rock Ridge name */
 				rrnamelen = 0;
-		
+
 				/* Check for Rock Ridge NM extension */
 				len = de->length - sizeof(iso_dirent_t)
 					+ sizeof(de->name) - de->name_len;
@@ -451,18 +451,18 @@ static iso_dirent_t *find_object(const char *fn, int dir, u32 dir_extent, u32 di
 					len -= pnt[2];
 					pnt += pnt[2];
 				}
-			
+
 				/* Check the filename against the requested one */
 				if (rrnamelen > 0) {
 					char *p = strchr(fn, '/');
 					int fnlen;
-				
+
 					if (p)
 						fnlen = p - fn;
 					else
 						fnlen = strlen(fn);
 
-					if (!strnicmp(rrname, fn, fnlen)) {
+					if (!strncasecmp(rrname, fn, fnlen)) {
 						if (!((dir << 1) ^ de->flags))
 							return de;
 					}
@@ -473,14 +473,14 @@ static iso_dirent_t *find_object(const char *fn, int dir, u32 dir_extent, u32 di
 					}
 				}
 			}
-			
+
 			i += de->length;
 		}
-		
+
 		dir_extent++;
 		size_left -= 2048;
 	}
-	
+
 	return NULL;
 }
 
@@ -492,7 +492,7 @@ static iso_dirent_t *find_object(const char *fn, int dir, u32 dir_extent, u32 di
    dir:		0 if looking for a file, 1 if looking for a dir
    dir_extent:	directory extent to start with
    dir_size:	directory size (in bytes)
-   
+
    It will return a pointer to a transient dirent buffer (i.e., don't
    expect this buffer to stay around much longer than the call itself).
  */
@@ -506,7 +506,7 @@ static iso_dirent_t *find_object_path(const char *fn, int dir, iso_dirent_t *sta
 			/* Note: trailing path parts don't matter since find_object
 			   only compares based on the FN length on the disc. */
 			start = find_object(fn, 1, iso_733(start->extent), iso_733(start->size));
-			if (start == NULL) 
+			if (start == NULL)
 				return NULL;
 		}
 		fn = cur + 1;
@@ -568,7 +568,7 @@ static int iso_open(const char *fn, int mode) {
 	/* Make sure they don't want to open things as writeable */
 	if (mode != O_RDONLY && mode != O_DIR)
 		return 0;
-	
+
 	/* Do this only when we need to (this is still imperfect) */
 	if (!percd_done && init_percd() < 0)
 		return 0;
@@ -576,9 +576,9 @@ static int iso_open(const char *fn, int mode) {
 
 	/* Find the file we want */
 	de = find_object_path(fn, (mode & O_DIR)?1:0, &root_dirent);
-	if (!de)	
+	if (!de)
 		return 0;
-	
+
 	/* Find a free file handle */
 	lock(fh_mutex);
 	for (fd=0; fd<MAX_ISO_FILES; fd++){
@@ -597,7 +597,7 @@ static int iso_open(const char *fn, int mode) {
 	fh[fd].ptr = 0;
 	fh[fd].size = iso_733(de->size);
 	fh[fd].broken = 0;
-	
+
 	return fd;
 }
 
@@ -616,8 +616,8 @@ static ssize_t iso_read(int fd, void *buf, size_t bytes) {
 	u8 * outbuf;
 
 	/* Check that the fd is valid */
-	if (fd >= MAX_ISO_FILES || fh[fd].first_extent == 0 || fh[fd].broken)	
-		return -1;	
+	if (fd >= MAX_ISO_FILES || fh[fd].first_extent == 0 || fh[fd].broken)
+		return -1;
 
 	rv = 0;
 	outbuf = (u8 *)buf;
@@ -650,17 +650,19 @@ static ssize_t iso_read(int fd, void *buf, size_t bytes) {
 				thissect);*/
 
 			// Do the read
-			if (iso9660_dev->readSectors(fh[fd].first_extent + fh[fd].ptr/2048, thissect, outbuf) < 0)
+			// NOTE[TJ]: why is it checking if a bool is less than zero??????
+			// if (iso9660_dev->readSectors(fh[fd].first_extent + fh[fd].ptr/2048, thissect, outbuf) < 0)
+			if (!iso9660_dev->readSectors(fh[fd].first_extent + fh[fd].ptr/2048, thissect, outbuf))
 				return -2; // Something went wrong...
-		} else { 
+		} else {
 			toread = (toread > thissect) ? thissect : toread;
-		
+
 			/* Do the read */
 			c = bdread(fh[fd].first_extent + fh[fd].ptr/2048);
-			if (c < 0)			
-				return -3;			
+			if (c < 0)
+				return -3;
 			memcpy(outbuf, dcache[c]->data + (fh[fd].ptr%2048), toread);
-		} 
+		}
 
 		/* Adjust pointers */
 		outbuf += toread;
@@ -692,11 +694,11 @@ static off_t iso_seek(int fd, off_t offset, int whence) {
 		default:
 			return -1;
 	}
-	
+
 	/* Check bounds */
 	if (fh[fd].ptr < 0) fh[fd].ptr = 0;
 	if (fh[fd].ptr > fh[fd].size) fh[fd].ptr = fh[fd].size;
-	
+
 	return fh[fd].ptr;
 }
 
@@ -752,7 +754,7 @@ static struct dirent *iso_readdir(int fd) {
 		/* Get the current dirent block */
 		c = biread(fh[fd].first_extent + fh[fd].ptr/2048);
 		if (c < 0) return NULL;
-	
+
 		de = (iso_dirent_t *)(icache[c]->data + (fh[fd].ptr%2048));
 		if (de->length) break;
 
@@ -760,7 +762,7 @@ static struct dirent *iso_readdir(int fd) {
 		fh[fd].ptr += 2048 - (fh[fd].ptr%2048);
 	}
 	if (fh[fd].ptr >= fh[fd].size) return NULL;
-	
+
 	/* If we're at the first, skip the two blank entries */
 	if (!de->name[0] && de->name_len == 1) {
 		fh[fd].ptr += de->length;
@@ -793,7 +795,7 @@ static struct dirent *iso_readdir(int fd) {
 			pnt += pnt[2];
 		}
 	}
-	
+
 	//fh[fd].dirent.d_namlen = de->name_len;
 
 	if (de->flags & 2){
@@ -805,7 +807,7 @@ static struct dirent *iso_readdir(int fd) {
 	}
 
 	fh[fd].ptr += de->length;
-	
+
 	return &fh[fd].dirent;
 }
 
@@ -853,10 +855,10 @@ int fs_iso9660_init() {
 
 	/* Reset fd's */
 	memset(fh, 0, sizeof(fh));
-	
+
 	/* Mark the first as active so we can have an error FD of zero */
 	fh[0].first_extent = -1;
-	
+
 	/* Init thread mutexes */
 	cache_mutex = malloc(sizeof(u32));
 	fh_mutex = malloc(sizeof(u32));
@@ -896,7 +898,7 @@ int fs_iso9660_shutdown() {
 	if (fh_mutex != NULL)
 		free(fh_mutex);
 	cache_mutex = fh_mutex = NULL;
-	
+
 	return 0;
 }
 
@@ -1062,20 +1064,20 @@ static int _ISO9660_dirclose_r(struct _reent *r, DIR_ITER *dirState)
 static int _ISO9660_statvfs_r(struct _reent *r, const char *path, struct statvfs *buf)
 {
 	// FAT clusters = POSIX blocks
-	buf->f_bsize = 0x800; // File system block size. 
-	buf->f_frsize = 0x800; // Fundamental file system block size. 
+	buf->f_bsize = 0x800; // File system block size.
+	buf->f_frsize = 0x800; // Fundamental file system block size.
 
-	//buf->f_blocks	= totalsectors; // Total number of blocks on file system in units of f_frsize. 
-	buf->f_bfree = 0; // Total number of free blocks. 
-	buf->f_bavail = 0; // Number of free blocks available to non-privileged process. 
+	//buf->f_blocks	= totalsectors; // Total number of blocks on file system in units of f_frsize.
+	buf->f_bfree = 0; // Total number of free blocks.
+	buf->f_bavail = 0; // Number of free blocks available to non-privileged process.
 
 	// Treat requests for info on inodes as clusters
-	//buf->f_files = totalentries;	// Total number of file serial numbers. 
-	buf->f_ffree = 0; // Total number of free file serial numbers. 
-	buf->f_favail = 0; // Number of file serial numbers available to non-privileged process. 
+	//buf->f_files = totalentries;	// Total number of file serial numbers.
+	buf->f_ffree = 0; // Total number of free file serial numbers.
+	buf->f_favail = 0; // Number of file serial numbers available to non-privileged process.
 
 	// File system ID. 32bit ioType value
-	buf->f_fsid = 0; //??!!? 
+	buf->f_fsid = 0; //??!!?
 
 	// Bit mask of f_flag values.
 	buf->f_flag = ST_NOSUID // No support for ST_ISUID and ST_ISGID file mode bits
@@ -1157,7 +1159,7 @@ bool ISO9660_Mount(const char* name, const DISC_INTERFACE *disc_interface)
 static bool check_dev_name(const char* name, char *devname, size_t devname_size)
 {
     size_t len;
-    
+
 	if (!name)
 		return false;
 
@@ -1178,7 +1180,7 @@ bool ISO9660_Unmount(const char* name)
 	char devname[11];
 	if (! check_dev_name(name, devname, sizeof(devname)))
 		return false;
-	fs_iso9660_shutdown();	
+	fs_iso9660_shutdown();
 	if (RemoveDevice(name) == -1)
 		return false;
 	return true;

--- a/libxenon/ports/bzip2/bzip2-1.0.8.diff
+++ b/libxenon/ports/bzip2/bzip2-1.0.8.diff
@@ -1,0 +1,83 @@
+--- bzip2-1.0.8/Makefile	2022-11-16 23:05:18.421945702 +0000
++++ bzip2-1.0.8/Makefile-new	2022-11-16 23:05:34.018072573 +0000
+@@ -14,17 +14,19 @@
+ 
+ SHELL=/bin/sh
+ 
++MACHDEP =  -DXENON -m32 -mno-altivec -fno-pic  -fno-pic -mpowerpc64 -mhard-float -L$(DEVKITXENON)/usr -L$(DEVKITXENON)/xenon/lib/32
++
+ # To assist in cross-compiling
+-CC=gcc
+-AR=ar
+-RANLIB=ranlib
+-LDFLAGS=
++CC=xenon-gcc
++AR=xenon-ar
++RANLIB=xenon-ranlib
++LDFLAGS=-lxenon
+ 
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS=-Wall -Winline -O2 -g $(BIGFILES) $(MACHDEP)
+ 
+ # Where you want it installed when you do 'make install'
+-PREFIX=/usr/local
++PREFIX=$(DEVKITXENON)/usr
+ 
+ 
+ OBJS= blocksort.o  \
+@@ -35,7 +37,7 @@
+       decompress.o \
+       bzlib.o
+ 
+-all: libbz2.a bzip2 bzip2recover test
++all: libbz2.a
+ 
+ bzip2: libbz2.a bzip2.o
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2 bzip2.o -L. -lbz2
+@@ -69,44 +71,15 @@
+ 	cmp sample3.tst sample3.ref
+ 	@cat words3
+ 
+-install: bzip2 bzip2recover
+-	if ( test ! -d $(PREFIX)/bin ) ; then mkdir -p $(PREFIX)/bin ; fi
++install:
+ 	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
+ 	if ( test ! -d $(PREFIX)/man ) ; then mkdir -p $(PREFIX)/man ; fi
+ 	if ( test ! -d $(PREFIX)/man/man1 ) ; then mkdir -p $(PREFIX)/man/man1 ; fi
+ 	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
+-	cp -f bzip2 $(PREFIX)/bin/bzip2
+-	cp -f bzip2 $(PREFIX)/bin/bunzip2
+-	cp -f bzip2 $(PREFIX)/bin/bzcat
+-	cp -f bzip2recover $(PREFIX)/bin/bzip2recover
+-	chmod a+x $(PREFIX)/bin/bzip2
+-	chmod a+x $(PREFIX)/bin/bunzip2
+-	chmod a+x $(PREFIX)/bin/bzcat
+-	chmod a+x $(PREFIX)/bin/bzip2recover
+-	cp -f bzip2.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzip2.1
+ 	cp -f bzlib.h $(PREFIX)/include
+ 	chmod a+r $(PREFIX)/include/bzlib.h
+ 	cp -f libbz2.a $(PREFIX)/lib
+ 	chmod a+r $(PREFIX)/lib/libbz2.a
+-	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
+-	chmod a+x $(PREFIX)/bin/bzgrep
+-	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
+-	chmod a+x $(PREFIX)/bin/bzmore
+-	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
+-	chmod a+x $(PREFIX)/bin/bzdiff
+-	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzgrep.1
+-	chmod a+r $(PREFIX)/man/man1/bzmore.1
+-	chmod a+r $(PREFIX)/man/man1/bzdiff.1
+-	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzegrep.1
+-	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzfgrep.1
+-	echo ".so man1/bzmore.1" > $(PREFIX)/man/man1/bzless.1
+-	echo ".so man1/bzdiff.1" > $(PREFIX)/man/man1/bzcmp.1
+ 
+ clean:
+ 	rm -f *.o libbz2.a bzip2 bzip2recover \

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -302,6 +302,22 @@ function freetype_install
 	echo -e "Done"
 }
 
+# pass the repo name to this function
+function sdl_install
+{
+	echo -e "Cloning $1... "
+	git clone https://github.com/ITotalJustice/$1.git  >> $LOGFILE 2>&1 || fail_with_info
+	echo -e "Building $1... "
+	cd $1
+	make -f Makefile.xenon >> $LOGFILE 2>&1 || fail_with_info
+	echo -e "Installing $1... "
+	make -f Makefile.xenon install >> $LOGFILE 2>&1 || fail_with_info
+
+	cd ..
+	rm -rf $1
+	echo -e "Done"
+}
+
 function filesystems_install
 {
 	echo -e "Building Filesystems..."
@@ -449,6 +465,10 @@ elif [ "$1" == "libs" ]; then
     bzip2_install
     libpng_install
     freetype_install
+	sdl_install libSDLXenon
+	sdl_install libSDL_ImageXenon
+	sdl_install libSDL_MixerXenon
+	sdl_install libSDL_TTFXenon
     bin2s_install
     filesystems_install
 elif [ "$1" == "libxenon" ]; then
@@ -461,10 +481,18 @@ elif [ "$1" == "bzip2" ]; then
     bzip2_install
 elif [ "$1" == "freetype" ]; then
     freetype_install
+elif [ "$1" == "sdl" ]; then
+    sdl_install libSDLXenon
+elif [ "$1" == "sdl_image" ]; then
+    sdl_install libSDL_ImageXenon
+elif [ "$1" == "sdl_mixer" ]; then
+    sdl_install libSDL_MixerXenon
+elif [ "$1" == "sdl_ttf" ]; then
+    sdl_install libSDL_TTFXenon
 elif [ "$1" == "filesystems" ]; then
     filesystems_install
 elif [ "$1" == "bin2s" ]; then
-        bin2s_install
+	bin2s_install
 elif [ "$1" == "cube" ]; then
     cube
 else
@@ -476,6 +504,10 @@ else
     echo -e "\"$0 libpng\" (install or update libpng)"
     echo -e "\"$0 bzip2\" (install or update bzip2)"
     echo -e "\"$0 freetype\" (install or update freetype)"
+    echo -e "\"$0 sdl\" (install or update sdl)"
+    echo -e "\"$0 sdl_image\" (install or update sdl_image)"
+    echo -e "\"$0 sdl_mixer\" (install or update sdl_mixer)"
+    echo -e "\"$0 sdl_ttf\" (install or update sdl_ttf)"
     echo -e "\"$0 filesystems\" (install libxenon filesystems)"
     echo -e "\"$0 cube\" (compile the cube sample)"
     echo

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -4,7 +4,9 @@
 # changed for xenon by Felix Domke <tmbinc@elitedvb.net>, still public domain
 
 TARGET=xenon
-PREFIX=${PREFIX:-/usr/local/xenon} # Install location of your final toolchain
+# Install location of your final toolchain
+PREFIX=${PREFIX:-${DEVKITXENON}} # try PREFIX, fallback to DEVKITXENON
+PREFIX=${PREFIX:-/usr/local/xenon} # if PREFIX and DEVKITXENON not set, fallback to /usr/local/xenon
 PARALLEL=
 
 BINUTILS=binutils-2.32
@@ -12,10 +14,10 @@ GCC=gcc-9.2.0
 NEWLIB=newlib-3.1.0
 GDB=gdb-6.8
 
-ZLIB=zlib-1.2.11
-LIBPNG=libpng-1.5.10
-BZIP2=bzip2-1.0.6
-FREETYPE=freetype-2.10.4
+ZLIB=zlib-1.2.13
+LIBPNG=libpng-1.5.30
+BZIP2=bzip2-1.0.8
+FREETYPE=freetype-2.12.1
 
 # build stages
 BUILD_BINUTILS=true
@@ -178,7 +180,8 @@ function zlib_install
 {
 	if [ ! -f "$ZLIB.tar.gz" ]; then
 		echo -e "Downloading $ZLIB.tar.gz"
-		wget -c http://zlib.net/$ZLIB.tar.gz || fail_with_info
+		# if this breaks again, use github
+		wget -c https://www.zlib.net/fossils/$ZLIB.tar.gz || fail_with_info
 	fi;
 
 	echo -e "Extracting zlib..."
@@ -233,7 +236,7 @@ function libpng_install
 
 	echo -e "Building libpng..."
 	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing libpng..."	
+	echo -e "Installing libpng..."
 	make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
 	cd ..
 	rm -rf $LIBPNG
@@ -272,7 +275,7 @@ function freetype_install
 		echo -e "Downloading $FREETYPE.tar.gz"
 		wget -c http://download.savannah.gnu.org/releases/freetype/$FREETYPE.tar.gz || fail_with_info
 	fi;
-	
+
 	echo -e "Extracting freetype..."
 	rm -rf $FREETYPE
 	tar xzf $FREETYPE.tar.gz >> $LOGFILE 2>&1 || fail_with_info
@@ -283,7 +286,7 @@ function freetype_install
 	export LDFLAGS="$CFLAGS"
 
 	echo -e "Configuring freetype..."
-	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared >> $LOGFILE 2>&1 || fail_with_info
+	./configure --without-harfbuzz --without-brotli --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared >> $LOGFILE 2>&1 || fail_with_info
 
 	echo -e "Building freetype..."
 	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
@@ -303,7 +306,7 @@ function filesystems_install
 {
 	echo -e "Building Filesystems..."
 
-	filesystems="fat-xenon ext2fs-xenon xtaflib" # ntfs-xenon ext2fs-xenon xtaflib
+	filesystems="fat-xenon ext2fs-xenon libxtaf libntfs"
 
 	for i in $filesystems
 	do
@@ -315,12 +318,12 @@ function filesystems_install
 				cd $i
 				git checkout $FSBRANCH >> $LOGFILE 2>&1
 				cd ..
-			fi			
+			fi
 		else
 			cd $i
 			if [ "" != "$FSBRANCH" ]; then
 				git checkout $FSBRANCH >> $LOGFILE 2>&1
-			fi	
+			fi
 			git remote update >> $LOGFILE 2>&1
 			git status -uno | grep -q behind
 			if [ 0 -eq $? ]; then
@@ -365,15 +368,15 @@ function cube
 		cp ../devkitxenon/examples/xenon/graphics/cube/cube.elf32 .
 		echo
 		echo -e "cube.elf32 compiled, run it via xell"
-		echo		
-		
+		echo
+
 	else
 		echo
 		echo -e "git is needed to download libxenon, install it and run this script again with \"libxenon\" as argument"
 		echo -e "If you are running debian/ubuntu : apt install git"
 		echo
 	fi
-	exit 0	
+	exit 0
 }
 
 function all_done


### PR DESCRIPTION
upgrades:
zlib 1.2.11 -> 1.2.13
libpng 1.5.10 -> 1.5.30
bzip2 1.0.6 -> 1.0.8
freetype 2.10.4 -> 2.12.1

fixes:
- updated broke zlib url
- bzip2 was detecting system installed libs (harfbuzz and brotli) so i disabled them
- add back ntfs lib
- iso9660.c was checking if a bool was negative...
- iso9660.c was using strnicmp instead of strncasecmp