### PR TITLE
Update toolchain and aux libraries

### DIFF
--- a/libxenon/include/xetypes.h
+++ b/libxenon/include/xetypes.h
@@ -9,6 +9,7 @@
 #endif /* __cplusplus */
 
 /*+----------------------------------------------------------------------------------------------+*/
+typedef unsigned int uint;	///< unsigned integer
 typedef uint8_t u8;					///< 8bit unsigned integer
 typedef uint16_t u16;				///< 16bit unsigned integer
 typedef uint32_t u32;				///< 32bit unsigned integer

--- a/libxenon/ports/bzip2/bzip2-1.0.8.diff
+++ b/libxenon/ports/bzip2/bzip2-1.0.8.diff
@@ -1,0 +1,84 @@
+diff -NurpP --minimal bzip2-1.0.8/Makefile bzip2-1.0.8-xenon/Makefile
+--- bzip2-1.0.8/Makefile	2010-09-11 00:46:02.000000000 +0200
++++ bzip2-1.0.8-xenon/Makefile	2011-09-21 20:57:54.000000000 +0200
+@@ -14,17 +14,19 @@
+ 
+ SHELL=/bin/sh
+ 
++MACHDEP =  -DXENON -m32 -mno-altivec -fno-pic  -fno-pic -mpowerpc64 -mhard-float -L/usr/local/xenon/usr -L/usr/local/xenon/xenon/lib/32
++
+ # To assist in cross-compiling
+-CC=gcc
+-AR=ar
++CC=xenon-gcc
++AR=xenon-ar
+ RANLIB=ranlib
+-LDFLAGS=
++LDFLAGS=-lxenon
+ 
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS=-Wall -Winline -O2 -g $(BIGFILES) $(MACHDEP)
+ 
+ # Where you want it installed when you do 'make install'
+-PREFIX=/usr/local
++PREFIX=/usr/local/xenon/usr/
+ 
+ 
+ OBJS= blocksort.o  \
+@@ -35,7 +37,7 @@ OBJS= blocksort.o  \
+       decompress.o \
+       bzlib.o
+ 
+-all: libbz2.a bzip2 bzip2recover test
++all: libbz2.a
+ 
+ bzip2: libbz2.a bzip2.o
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2 bzip2.o -L. -lbz2
+@@ -69,44 +71,16 @@ test: bzip2
+ 	cmp sample3.tst sample3.ref
+ 	@cat words3
+ 
+-install: bzip2 bzip2recover
+-	if ( test ! -d $(PREFIX)/bin ) ; then mkdir -p $(PREFIX)/bin ; fi
++install: 
+ 	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
+ 	if ( test ! -d $(PREFIX)/man ) ; then mkdir -p $(PREFIX)/man ; fi
+ 	if ( test ! -d $(PREFIX)/man/man1 ) ; then mkdir -p $(PREFIX)/man/man1 ; fi
+ 	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
+-	cp -f bzip2 $(PREFIX)/bin/bzip2
+-	cp -f bzip2 $(PREFIX)/bin/bunzip2
+-	cp -f bzip2 $(PREFIX)/bin/bzcat
+-	cp -f bzip2recover $(PREFIX)/bin/bzip2recover
+-	chmod a+x $(PREFIX)/bin/bzip2
+-	chmod a+x $(PREFIX)/bin/bunzip2
+-	chmod a+x $(PREFIX)/bin/bzcat
+-	chmod a+x $(PREFIX)/bin/bzip2recover
+-	cp -f bzip2.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzip2.1
+ 	cp -f bzlib.h $(PREFIX)/include
+ 	chmod a+r $(PREFIX)/include/bzlib.h
+ 	cp -f libbz2.a $(PREFIX)/lib
+ 	chmod a+r $(PREFIX)/lib/libbz2.a
+-	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
+-	chmod a+x $(PREFIX)/bin/bzgrep
+-	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
+-	chmod a+x $(PREFIX)/bin/bzmore
+-	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
+-	chmod a+x $(PREFIX)/bin/bzdiff
+-	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzgrep.1
+-	chmod a+r $(PREFIX)/man/man1/bzmore.1
+-	chmod a+r $(PREFIX)/man/man1/bzdiff.1
+-	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzegrep.1
+-	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzfgrep.1
+-	echo ".so man1/bzmore.1" > $(PREFIX)/man/man1/bzless.1
+-	echo ".so man1/bzdiff.1" > $(PREFIX)/man/man1/bzcmp.1
++	
+ 
+ clean: 
+ 	rm -f *.o libbz2.a bzip2 bzip2recover \

--- a/libxenon/ports/xenon/Makefile
+++ b/libxenon/ports/xenon/Makefile
@@ -20,7 +20,7 @@ INCLUDES = -I ../../drivers -I ../../include \
 CFLAGS = -g -mcpu=cell -mtune=cell -Os \
 	-maltivec \
 	-ffunction-sections -fdata-sections \
-	-Wall -Wno-format -Wno-attributes -I. -DBYTE_ORDER=BIG_ENDIAN \
+	-Wall -Wno-format -Wno-attributes -fpermissive -I. -DBYTE_ORDER=BIG_ENDIAN \
 	-m32 -fno-pic -mpowerpc64 \
 	-D_CFE_=1 -DENDIAN_BIG=1 \
 	$(INCLUDES)

--- a/toolchain/binutils-2.43.1.diff
+++ b/toolchain/binutils-2.43.1.diff
@@ -1,0 +1,14 @@
+diff -ruN ../binutils-2.43.1/config.sub binutils-2.43.1/config.sub
+--- ../binutils-2.43.1/config.sub	2024-08-17 00:00:00.000000000 +0100
++++ binutils-2.43.1/config.sub	2024-12-03 04:03:37.186489604 +0000
+@@ -884,6 +884,10 @@
+ 		cpu=power
+ 		vendor=ibm
+ 		;;
++	xenon)
++		cpu=powerpc64
++		basic_os=linux
++		;;
+ 	ps2)
+ 		cpu=i386
+ 		vendor=ibm

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -12,10 +12,10 @@ GCC=gcc-14.2.0
 NEWLIB=newlib-4.4.0.20231231
 GDB=gdb-15.1
 
-ZLIB=zlib-1.2.11
-LIBPNG=libpng-1.5.10
-BZIP2=bzip2-1.0.6
-FREETYPE=freetype-2.10.4
+ZLIB=zlib-1.3.1
+LIBPNG=libpng-1.5.30
+BZIP2=bzip2-1.0.8
+FREETYPE=freetype-2.13.3
 
 # build stages
 BUILD_BINUTILS=true
@@ -303,7 +303,7 @@ function filesystems_install
 {
 	echo -e "Building Filesystems..."
 
-	filesystems="fat-xenon ext2fs-xenon xtaflib" # ntfs-xenon ext2fs-xenon xtaflib
+	filesystems="fat-xenon ext2fs-xenon" # xtaflib ntfs-xenon ext2fs-xenon xtaflib
 
 	for i in $filesystems
 	do

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -7,10 +7,10 @@ TARGET=xenon
 PREFIX=${PREFIX:-/usr/local/xenon} # Install location of your final toolchain
 PARALLEL=
 
-BINUTILS=binutils-2.32
-GCC=gcc-9.2.0
-NEWLIB=newlib-3.1.0
-GDB=gdb-6.8
+BINUTILS=binutils-2.43.1
+GCC=gcc-14.2.0
+NEWLIB=newlib-4.4.0.20231231
+GDB=gdb-15.1
 
 ZLIB=zlib-1.2.11
 LIBPNG=libpng-1.5.10
@@ -161,7 +161,7 @@ function toolchain_install
           ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local --with-cpu=cell \
                   --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
                   --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
-                  --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
+                  --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-libstdcxx-time=no --enable-altivec \
                   --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
           echo -e "Building gcc - 2nd pass, this could take a while..."
           make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
@@ -189,7 +189,7 @@ function zlib_install
 	export TARGET_SAVE=$TARGET
 	export CC=$TARGET-gcc
 	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 -Wno-error -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
+	export LDFLAGS=""
 	export TARGET=`gcc -v 2>&1 | sed -n '2p' | awk '{print $2}'`
 
 	echo -e "Configuring zlib..."
@@ -226,7 +226,7 @@ function libpng_install
 
 	export CC=$TARGET-gcc
 	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32 -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
+	export LDFLAGS=""
 
 	echo -e "Configuring libpng..."
 	./configure --disable-shared --enable-static --prefix=$DEVKITXENON/usr --host=ppc-elf >> $LOGFILE 2>&1 || fail_with_info
@@ -280,7 +280,7 @@ function freetype_install
 
 	export CC=$TARGET-gcc
 	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
+	export LDFLAGS=""
 
 	echo -e "Configuring freetype..."
 	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared >> $LOGFILE 2>&1 || fail_with_info

--- a/toolchain/gcc-14.2.0.diff
+++ b/toolchain/gcc-14.2.0.diff
@@ -1,0 +1,190 @@
+diff -ruN ../gcc-14.2.0/config.sub gcc-14.2.0/config.sub
+--- ../gcc-14.2.0/config.sub	2024-08-01 09:17:13.000000000 +0100
++++ gcc-14.2.0/config.sub	2024-12-03 03:05:07.420714106 +0000
+@@ -883,6 +883,10 @@
+ 		cpu=power
+ 		vendor=ibm
+ 		;;
++	xenon)
++		cpu=powerpc64
++		basic_os=linux
++		;;
+ 	ps2)
+ 		cpu=i386
+ 		vendor=ibm
+diff -ruN ../gcc-14.2.0/gcc/config/rs6000/altivec.md gcc-14.2.0/gcc/config/rs6000/altivec.md
+--- ../gcc-14.2.0/gcc/config/rs6000/altivec.md	2024-08-01 09:17:14.000000000 +0100
++++ gcc-14.2.0/gcc/config/rs6000/altivec.md	2024-12-03 03:14:37.514807472 +0000
+@@ -1009,7 +1009,7 @@
+ 		      (match_operand:VIshort 2 "register_operand" "v")
+                       (match_operand:V4SI 3 "register_operand" "v")]
+ 		     UNSPEC_VMSUMU))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmsumu<VI_char>m %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1029,7 +1029,7 @@
+ 		      (match_operand:VIshort 2 "register_operand" "v")
+                       (match_operand:V4SI 3 "register_operand" "v")]
+ 		     UNSPEC_VMSUMM))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmsumm<VI_char>m %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1039,7 +1039,7 @@
+ 		      (match_operand:V8HI 2 "register_operand" "v")
+                       (match_operand:V4SI 3 "register_operand" "v")]
+ 		     UNSPEC_VMSUMSHM))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmsumshm %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1050,7 +1050,7 @@
+                       (match_operand:V4SI 3 "register_operand" "v")]
+ 		     UNSPEC_VMSUMUHS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmsumuhs %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1061,7 +1061,7 @@
+                       (match_operand:V4SI 3 "register_operand" "v")]
+ 		     UNSPEC_VMSUMSHS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmsumshs %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1122,7 +1122,7 @@
+                       (match_operand:V8HI 3 "register_operand" "v")]
+ 		     UNSPEC_VMHADDSHS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmhaddshs %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1133,7 +1133,7 @@
+                       (match_operand:V8HI 3 "register_operand" "v")]
+ 		     UNSPEC_VMHRADDSHS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmhraddshs %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1142,7 +1142,7 @@
+         (plus:V8HI (mult:V8HI (match_operand:V8HI 1 "register_operand" "v")
+ 		   	      (match_operand:V8HI 2 "register_operand" "v"))
+ 		   (match_operand:V8HI 3 "register_operand" "v")))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmladduhm %0,%1,%2,%3"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1759,7 +1759,7 @@
+         (unspec:V8HI [(match_operand:V16QI 1 "register_operand" "v")
+                       (match_operand:V16QI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULEUB))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmuleub %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1768,7 +1768,7 @@
+         (unspec:V8HI [(match_operand:V16QI 1 "register_operand" "v")
+                       (match_operand:V16QI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULOUB))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmuloub %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1777,7 +1777,7 @@
+         (unspec:V8HI [(match_operand:V16QI 1 "register_operand" "v")
+                       (match_operand:V16QI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULESB))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmulesb %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1786,7 +1786,7 @@
+         (unspec:V8HI [(match_operand:V16QI 1 "register_operand" "v")
+                       (match_operand:V16QI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULOSB))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmulosb %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1804,7 +1804,7 @@
+         (unspec:V4SI [(match_operand:V8HI 1 "register_operand" "v")
+                       (match_operand:V8HI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULOUH))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmulouh %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -1822,7 +1822,7 @@
+         (unspec:V4SI [(match_operand:V8HI 1 "register_operand" "v")
+                       (match_operand:V8HI 2 "register_operand" "v")]
+ 		     UNSPEC_VMULOSH))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vmulosh %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -2183,7 +2183,7 @@
+                       (match_operand:V4SI 2 "register_operand" "v")]
+ 		     UNSPEC_VSUM4UBS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vsum4ubs %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -2193,7 +2193,7 @@
+                       (match_operand:V4SI 2 "register_operand" "v")]
+ 		     UNSPEC_VSUM4S))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vsum4s<VI_char>s %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -2226,7 +2226,7 @@
+ 	              (match_operand:V4SI 2 "register_operand" "v")]
+ 		     UNSPEC_VSUM2SWS))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vsum2sws %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+@@ -2258,7 +2258,7 @@
+                       (match_operand:V4SI 2 "register_operand" "v")]
+ 		     UNSPEC_VSUMSWS_DIRECT))
+    (set (reg:SI VSCR_REGNO) (unspec:SI [(const_int 0)] UNSPEC_SET_VSCR))]
+-  "TARGET_ALTIVEC"
++  "(TARGET_ALTIVEC && 0)"
+   "vsumsws %0,%1,%2"
+   [(set_attr "type" "veccomplex")])
+ 
+diff -ruN ../gcc-14.2.0/libstdc++-v3/configure gcc-14.2.0/libstdc++-v3/configure
+--- ../gcc-14.2.0/libstdc++-v3/configure	2024-08-01 09:17:18.000000000 +0100
++++ gcc-14.2.0/libstdc++-v3/configure	2024-12-03 03:24:05.849152547 +0000
+@@ -11563,6 +11563,7 @@
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
++	lt_cv_shlibpath_overrides_runpath=no
+ 
+   # Some binutils ld are patched to set DT_RUNPATH
+   if ${lt_cv_shlibpath_overrides_runpath+:} false; then :

--- a/toolchain/newlib-4.4.0.20231231.diff
+++ b/toolchain/newlib-4.4.0.20231231.diff
@@ -1,0 +1,16 @@
+diff -ruN ../newlib-4.4.0.20231231/config.sub newlib-4.4.0.20231231/config.sub
+--- ../newlib-4.4.0.20231231/config.sub	2023-12-31 17:00:18.000000000 +0000
++++ newlib-4.4.0.20231231/config.sub	2024-12-03 20:26:12.842278137 +0000
+@@ -872,6 +872,12 @@
+ 		cpu=i386
+ 		vendor=ibm
+ 		;;
++	ppu)
++		cpu=powerpc64
++		;;
++	xenon)
++		cpu=powerpc64
++		;;
+ 	rm[46]00)
+ 		cpu=mips
+ 		vendor=siemens


### PR DESCRIPTION
DON'T MERGE YET. LINUX LOADING/ELF LOADING IS BROKEN. I NEED TO MAKE CHANGES TO LIBXENON.

- GCC updated to 14.2.0
- Binutils updated to 2.43.1
- Newlib updated to 4.4.0
- Zlib updated to 1.3.1
- Libpng updated to 1.5.30 (could not get this working on 1.6 as of right now)
- Bzip2 updated to 1.0.8
- Freetype updated to 2.13.3

I also fixed up the fat-xenon and xenon-ext2fs filesystem drivers (yet to be tested but code changes I made were relatively minor and they compile), and I will look at fixing the others soon-ish. So please have a look at those pull requests as well, as the build script fails on the current versions on here.