### PR TITLE
Fix ECC calculation code for XeLL update to prevent console brick

### DIFF
--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (edc[0] & 0x3F)) & 0xFF;
+	edc[0] = (val << 6) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;

--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (data[0x20C] & 0x3F)) & 0xFF;
+	edc[0] = ((val << 6) | (data[0xC] & 0x3F)) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;

--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (data[0xC] & 0x3F)) & 0xFF;
+	edc[0] = ((val << 6) | (edc[0] & 0x3F)) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;


### PR DESCRIPTION
Reverts ECC calculation data change made by the following commit that bricks the console and results in bad block errors when applying updxell.bin.

https://github.com/Free60Project/libxenon/commit/9aeeefd897f413ddbec4409b6f12cfcd1540d168

I've verified that XeLL updates behave as expected with this PR.