### PR TITLE
Fix FreeType build (disable Brotli support)

### DIFF
--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -283,7 +283,7 @@ function freetype_install
 	export LDFLAGS="$CFLAGS"
 
 	echo -e "Configuring freetype..."
-	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared >> $LOGFILE 2>&1 || fail_with_info
+	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared --without-brotli >> $LOGFILE 2>&1 || fail_with_info
 
 	echo -e "Building freetype..."
 	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info


### PR DESCRIPTION
This pull request fixes building FreeType, which was failing due to a lack of the Brotli library (which was added as a requirement to FreeType in 2.10.2 for WOFF2 fonts). All it does is disable that library (it was not present in LibXenon in the first place, and porting it is non-trivial (we're missing some syscalls in Newlib for it to work)).