### PR TITLE
improve build-xenon-toolchain and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,34 +37,19 @@ Dependencies for Linux distributions using the `dnf` or `apt` package managers w
 - wget
 - file
 
-The main driving script to setup libxenon is at `toolchain/build-xenon-toolchain`. Please see below on how to use it.
-
-### Environment variables
-
-After installation of the toolchain, the following environment variables need to be populated.
-
-`DEVKITXENON` is depends on your chosen installation prefix location. The default is `/usr/local/xenon`:
-
-```
-DEVKITXENON=/usr/local/xenon
-PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
-```
-
-You may edit your ~/.bashrc to set these. Alternatively, you may execute `./build-xenon-toolchain env-cmd` to install a command named `xenon-env`. When you run that command, it will set those variables in a new shell.
+If you are not using a Linux system with either the `dnf` or `apt` package manager, ensure the above equivalents are installed before running the main driving script to setup LibXenon, which is named `toolchain/build-xenon-toolchain`. See below on how to use it.
 
 ### Prefix
 
-If you want to choose your own prefix, prepend it to the `./build-xenon-toolchain` invocation.
+By default the prefix is set to `/usr/local/xenon`. If you want to choose your own prefix, prepend it to the `./build-xenon-toolchain` invocation, i.e. `PREFIX="/home/username/xenon" ./build-xenon-toolchain toolchain`.
 
-e.g. `PREFIX=/home/username/xenon ./build-xenon-toolchain toolchain`
-
-### Installing toolchain and libxenon library
+### Installing the toolchain
 
 ```
 ./build-xenon-toolchain toolchain
 ```
 
-### Installing libxenon library (useful for updating just libxenon)
+### Installing the libxenon library
 
 ```
 ./build-xenon-toolchain libxenon
@@ -75,3 +60,15 @@ e.g. `PREFIX=/home/username/xenon ./build-xenon-toolchain toolchain`
 ```
 ./build-xenon-toolchain libs
 ```
+
+### Environment variables
+
+After installation of the toolchain, the following environment variables need to be populated:
+
+```
+DEVKITXENON="/usr/local/xenon"
+PATH="${PATH:+${PATH}:}"$DEVKITXENON"/bin:"$DEVKITXENON"/usr/bin"
+```
+`DEVKITXENON` depends on your chosen installation prefix location. The default value is `/usr/local/xenon` unless you changed it.
+
+You may edit your ~/.bashrc to set these in every shell automatically. Alternatively, you may execute `./build-xenon-toolchain env-cmd` to install a command named `xenon-env`. When you run that command, it will set those variables in a new shell.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker $ make
 
 ### Requirements
 
-Dependencies for debian
+Dependencies for Linux distributions using the `dnf` or `apt` package managers will automatically be installed for you. These include:
 
 - flex
 - bison
@@ -37,16 +37,20 @@ Dependencies for debian
 - wget
 - file
 
+The main driving script to setup libxenon is at `toolchain/build-xenon-toolchain`. Please see below on how to use it.
+
 ### Environment variables
 
 After installation of the toolchain, the following environment variables need to be populated.
 
-`DEVKITXENON` is dependencing on your chosen installation prefix location.
+`DEVKITXENON` is depends on your chosen installation prefix location. The default is `/usr/local/xenon`:
 
 ```
-DEVKITXENON="/usr/local/xenon"
-PATH="$PATH:$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
+DEVKITXENON=/usr/local/xenon
+PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
 ```
+
+You may edit your ~/.bashrc to set these. Alternatively, you may execute `./build-xenon-toolchain env-cmd` to install a command named `xenon-env`. When you run that command, it will set those variables in a new shell.
 
 ### Prefix
 
@@ -54,19 +58,19 @@ If you want to choose your own prefix, prepend it to the `./build-xenon-toolchai
 
 e.g. `PREFIX=/home/username/xenon ./build-xenon-toolchain toolchain`
 
-### Installing toolchain
+### Installing toolchain and libxenon library
 
 ```
 ./build-xenon-toolchain toolchain
 ```
 
-### Install libxenon library
+### Installing libxenon library (useful for updating just libxenon)
 
 ```
 ./build-xenon-toolchain libxenon
 ```
 
-### Install auxiliary libs
+### Installing auxiliary libs (libxenon, bin2s, zlib, libpng, bzip2, freetype, filesystems)
 
 ```
 ./build-xenon-toolchain libs

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -144,10 +144,10 @@ toolchain_install()
         cd build
         echo -e "Configuring $GCC..."
         ../$GCC/configure --target=$TARGET --prefix="$PREFIX" --with-libiconv-prefix=/opt/local -enable-interwork \
-        --enable-languages="c" --without-headers --disable-shared \
-        --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
-        --disable-decimal-float --enable-altivec \
-        --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
+            --enable-languages="c" --without-headers --disable-shared \
+            --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
+            --disable-decimal-float --enable-altivec \
+            --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $GCC, this could take a while..."
         make $PARALLEL all-gcc 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $GCC..."
@@ -165,8 +165,8 @@ toolchain_install()
         cd build
         echo -e "Configuring $NEWLIB..."
         ../$NEWLIB/configure --target=$TARGET --prefix="$PREFIX"  --enable-multilib --disable-nls \
-        CFLAGS="-DHAVE_BLKSIZE -O2"\
-        --enable-newlib-io-long-long --enable-newlib-io-long-double >> $LOGFILE 2>&1 || fail_with_info
+            CFLAGS="-DHAVE_BLKSIZE -O2" \
+            --enable-newlib-io-long-long --enable-newlib-io-long-double >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $NEWLIB, this could take a while..."
         make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $NEWLIB..."
@@ -182,10 +182,10 @@ toolchain_install()
         echo -e "Configuring $GCC (2nd pass)..."
         unset LIBRARY_PATH
         ../$GCC/configure --target=$TARGET --prefix="$PREFIX" --with-libiconv-prefix=/opt/local --with-cpu=cell \
-        --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
-        --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
-        --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
-        --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
+            --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
+            --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
+            --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
+            --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $GCC - (2nd pass), this could take a while..."
         make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $GCC (2nd pass)..."

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -4,7 +4,7 @@
 # changed for xenon by Felix Domke <tmbinc@elitedvb.net>, still public domain
 
 TARGET=xenon
-PREFIX=${PREFIX:-/usr/local/xenon} # Install location of your final toolchain. Never quoted because gcc fails to install to such things
+PREFIX="${PREFIX:-/usr/local/xenon}" # Install location of your final toolchain.
 PARALLEL=
 
 BINUTILS_DL="https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.gz"
@@ -44,32 +44,31 @@ cd "$(dirname "$0")"
 LOGFILE=build.log
 
 # temp variables export, same as xenon-env cmd does
-export DEVKITXENON=$PREFIX
-export PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
+export DEVKITXENON="$PREFIX"
+export PATH="${PATH:+${PATH}:}"$DEVKITXENON"/bin:"$DEVKITXENON"/usr/bin"
 
 check_priv()
 {
     # test if we can install stuff to $PREFIX
     if [ "$EUID" -ne 0 ]; then
-        mkdir -p $PREFIX
-        touch $PREFIX/check_priv 2>/dev/null
+        mkdir -p "$PREFIX"
+        touch "$PREFIX"/check_priv 2>/dev/null
 
-        if [ ! -f $PREFIX/check_priv ]; then
-            echo "For your selected prefix ($PREFIX), root privileges are required:"
+        if [ ! -f "$PREFIX"/check_priv ]; then
+            echo "For your selected prefix (\"$PREFIX\"), root privileges are required for this feature:"
             sudo "$@"
-            rm -f $PREFIX/check_priv
+            rm -f "$PREFIX"/check_priv
             exit 0
         fi
 
-        rm -f $PREFIX/check_priv
-        return
+        rm -f "$PREFIX"/check_priv
     fi    
 }
 
 fail_with_info()
 {
-	echo "[-] Script failed, check build.log!" >> /dev/stderr
-	exit 1
+    echo "[-] Script failed, check build.log!" >> /dev/stderr
+    exit 1
 }
 
 # to compile and install libxenon
@@ -88,7 +87,7 @@ libxenon_install()
 toolchain_install()
 {
     check_priv "$@"
-    chown -R `whoami`:`whoami` $PREFIX
+    chown -R `whoami`:`whoami` "$PREFIX"
 
     # Check if binutils sources are available, download it if needed
     if [ ! -f $BINUTILS.tar.gz ]; then
@@ -125,7 +124,7 @@ toolchain_install()
         fi
         cd build
         echo -e "Configuring $BINUTILS..."
-        ../$BINUTILS/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls --disable-werror >> $LOGFILE 2>&1 || fail_with_info
+        ../$BINUTILS/configure --target=$TARGET --prefix="$PREFIX"  --enable-multilib --disable-nls --disable-werror >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $BINUTILS, this could take a while..."
         make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $BINUTILS..."
@@ -144,11 +143,11 @@ toolchain_install()
         fi
         cd build
         echo -e "Configuring $GCC..."
-        ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local -enable-interwork \
-                --enable-languages="c" --without-headers --disable-shared \
-                --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
-                --disable-decimal-float --enable-altivec \
-                --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
+        ../$GCC/configure --target=$TARGET --prefix="$PREFIX" --with-libiconv-prefix=/opt/local -enable-interwork \
+        --enable-languages="c" --without-headers --disable-shared \
+        --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
+        --disable-decimal-float --enable-altivec \
+        --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $GCC, this could take a while..."
         make $PARALLEL all-gcc 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $GCC..."
@@ -165,7 +164,7 @@ toolchain_install()
         cat $NEWLIB.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
         cd build
         echo -e "Configuring $NEWLIB..."
-        ../$NEWLIB/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls \
+        ../$NEWLIB/configure --target=$TARGET --prefix="$PREFIX"  --enable-multilib --disable-nls \
         CFLAGS="-DHAVE_BLKSIZE -O2"\
         --enable-newlib-io-long-long --enable-newlib-io-long-double >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $NEWLIB, this could take a while..."
@@ -182,11 +181,11 @@ toolchain_install()
         cd build
         echo -e "Configuring $GCC (2nd pass)..."
         unset LIBRARY_PATH
-        ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local --with-cpu=cell \
-                --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
-                --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
-                --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
-                --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
+        ../$GCC/configure --target=$TARGET --prefix="$PREFIX" --with-libiconv-prefix=/opt/local --with-cpu=cell \
+        --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
+        --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
+        --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
+        --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
         echo -e "Building $GCC - (2nd pass), this could take a while..."
         make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
         echo -e "Installing $GCC (2nd pass)..."
@@ -203,244 +202,248 @@ zlib_install()
 {
     check_priv "$@"
 
-	if [ ! -f "$ZLIB.tar.gz" ]; then
-		echo -e "Downloading $ZLIB..."
-		wget -c $ZLIB_DL || fail_with_info
-	fi
+    if [ ! -f "$ZLIB.tar.gz" ]; then
+        echo -e "Downloading $ZLIB..."
+        wget -c $ZLIB_DL || fail_with_info
+    fi
 
-	echo -e "Extracting $ZLIB..."
-	rm -rf $ZLIB
-	tar xzf $ZLIB.tar.gz >> $LOGFILE 2>&1 || fail_with_info
-	cd $ZLIB
+    echo -e "Extracting $ZLIB..."
+    rm -rf $ZLIB
+    tar xzf $ZLIB.tar.gz >> $LOGFILE 2>&1 || fail_with_info
+    cd $ZLIB
 
-	export TARGET_SAVE=$TARGET
-	export CC=$TARGET-gcc
-	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 -Wno-error -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
-	export TARGET=`gcc -v 2>&1 | sed -n '2p' | awk '{print $2}'`
+    export TARGET_SAVE=$TARGET
+    export CC=$TARGET-gcc
+    export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 -Wno-error -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
+    export LDFLAGS="$CFLAGS"
+    export TARGET=`gcc -v 2>&1 | sed -n '2p' | awk '{print $2}'`
 
-	echo -e "Configuring $ZLIB..."
-	./configure --prefix=$DEVKITXENON/usr >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Configuring $ZLIB..."
+    ./configure --prefix=$DEVKITXENON/usr >> $LOGFILE 2>&1 || fail_with_info
 
-	sed '/cp $(SHAREDLIBV) $(DESTDIR)$(sharedlibdir)/d' Makefile > Makefile.xenon
+    sed '/cp $(SHAREDLIBV) $(DESTDIR)$(sharedlibdir)/d' Makefile > Makefile.xenon
 
-	echo -e "Building $ZLIB..."
-	make $PARALLEL -f Makefile.xenon CROSS_COMPILE=$TARGET- libz.a >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing $ZLIB..."
-	make -f Makefile.xenon CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
-	cd ..
-	rm -rf $ZLIB
+    echo -e "Building $ZLIB..."
+    make $PARALLEL -f Makefile.xenon CROSS_COMPILE=$TARGET- libz.a >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Installing $ZLIB..."
+    make -f Makefile.xenon CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
+    cd ..
+    rm -rf $ZLIB
 
-	export CC=""
-	export CFLAGS=""
-	export LDFLAGS=""
-	export TARGET=$TARGET_SAVE
+    export CC=""
+    export CFLAGS=""
+    export LDFLAGS=""
+    export TARGET=$TARGET_SAVE
 
-	echo -e "Done"
+    echo -e "Done"
 }
 
 libpng_install()
 {
     check_priv "$@"
 
-	if [ ! -f "$LIBPNG.tar.xz" ]; then
-		echo -e "Downloading $LIBPNG..."
-		wget -c $LIBPNG_DL || fail_with_info
-	fi
+    if [ ! -f "$LIBPNG.tar.xz" ]; then
+        echo -e "Downloading $LIBPNG..."
+        wget -c $LIBPNG_DL || fail_with_info
+    fi
 
-	echo -e "Extracting $LIBPNG..."
-	rm -rf $LIBPNG
-	tar xJf $LIBPNG.tar.xz >> $LOGFILE 2>&1 || fail_with_info
-	cd $LIBPNG
+    echo -e "Extracting $LIBPNG..."
+    rm -rf $LIBPNG
+    tar xJf $LIBPNG.tar.xz >> $LOGFILE 2>&1 || fail_with_info
+    cd $LIBPNG
 
-	export CC=$TARGET-gcc
-	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32 -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
+    export CC=$TARGET-gcc
+    export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32 -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
+    export LDFLAGS="$CFLAGS"
 
-	echo -e "Configuring $LIBPNG..."
-	./configure --disable-shared --enable-static --prefix=$DEVKITXENON/usr --host=ppc-elf >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Configuring $LIBPNG..."
+    ./configure --disable-shared --enable-static --prefix=$DEVKITXENON/usr --host=ppc-elf >> $LOGFILE 2>&1 || fail_with_info
 
-	echo -e "Building $LIBPNG..."
-	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing $LIBPNG..."	
-	make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
-	cd ..
-	rm -rf $LIBPNG
+    echo -e "Building $LIBPNG..."
+    make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Installing $LIBPNG..."	
+    make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
+    cd ..
+    rm -rf $LIBPNG
 
     export CC=""
     export CFLAGS=""
     export LDFLAGS=""
 
-	echo -e "Done"
+    echo -e "Done"
 }
 
 bzip2_install()
 {
     check_priv "$@"
 
-	if [ ! -f "$BZIP2.tar.gz" ]; then
-		echo -e "Downloading $BZIP2..."
-		wget -c $BZIP2_DL || fail_with_info
-	fi
+    if [ ! -f "$BZIP2.tar.gz" ]; then
+        echo -e "Downloading $BZIP2..."
+        wget -c $BZIP2_DL || fail_with_info
+    fi
 
-	echo -e "Extracting $BZIP2..."
-	rm -rf $BZIP2
-	tar xzf $BZIP2.tar.gz >> $LOGFILE 2>&1 && cat ../libxenon/ports/bzip2/$BZIP2.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
-	cd $BZIP2
+    echo -e "Extracting $BZIP2..."
+    rm -rf $BZIP2
+    tar xzf $BZIP2.tar.gz >> $LOGFILE 2>&1 && cat ../libxenon/ports/bzip2/$BZIP2.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
+    cd $BZIP2
 
-	echo -e "Building $BZIP2..."
-	make $PARALLEL >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing $BZIP2..."
-	make install >> $LOGFILE 2>&1 || fail_with_info
-	cd ..
-	rm -rf $BZIP2
-	echo -e "Done"
+    echo -e "Building $BZIP2..."
+    make $PARALLEL >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Installing $BZIP2..."
+    make install >> $LOGFILE 2>&1 || fail_with_info
+    cd ..
+    rm -rf $BZIP2
+    echo -e "Done"
 }
 
 freetype_install()
 {
     check_priv "$@"
 
-	if [ ! -f "$FREETYPE.tar.gz" ]; then
-		echo -e "Downloading $FREETYPE..."
-		wget -c $FREETYPE_DL || fail_with_info
-	fi
-	
-	echo -e "Extracting $FREETYPE..."
-	rm -rf $FREETYPE
-	tar xzf $FREETYPE.tar.gz >> $LOGFILE 2>&1 || fail_with_info
-	cd $FREETYPE
+    if [ ! -f "$FREETYPE.tar.gz" ]; then
+        echo -e "Downloading $FREETYPE..."
+        wget -c $FREETYPE_DL || fail_with_info
+    fi
+    
+    echo -e "Extracting $FREETYPE..."
+    rm -rf $FREETYPE
+    tar xzf $FREETYPE.tar.gz >> $LOGFILE 2>&1 || fail_with_info
+    cd $FREETYPE
 
-	export CC=$TARGET-gcc
-	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
-	export LDFLAGS="$CFLAGS"
+    export CC=$TARGET-gcc
+    export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
+    export LDFLAGS="$CFLAGS"
 
-	echo -e "Configuring $FREETYPE..."
-	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared --without-brotli >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Configuring $FREETYPE..."
+    ./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared --without-brotli >> $LOGFILE 2>&1 || fail_with_info
 
-	echo -e "Building $FREETYPE..."
-	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing $FREETYPE..."
-	make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
-	cd ..
-	rm -rf $FREETYPE
+    echo -e "Building $FREETYPE..."
+    make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
+    echo -e "Installing $FREETYPE..."
+    make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
+    cd ..
+    rm -rf $FREETYPE
 
-	export CC=""
-	export CFLAGS=""
-	export LDFLAGS=""
+    export CC=""
+    export CFLAGS=""
+    export LDFLAGS=""
 
-	echo -e "Done"
+    echo -e "Done"
 }
 
 filesystems_install()
 {
     check_priv "$@"
-	echo -e "Building Filesystems..."
+    echo -e "Building Filesystems..."
 
-	filesystems="fat-xenon ext2fs-xenon xtaflib" # ntfs-xenon ext2fs-xenon xtaflib
+    filesystems="fat-xenon ext2fs-xenon xtaflib" # ntfs-xenon ext2fs-xenon xtaflib
 
-	for i in $filesystems
-	do
-		echo -e -n "$i: "
-		if [ ! -d $i ]; then
-			echo -e -n "Cloning... "
-			git clone https://github.com/Free60Project/$i.git  >> $LOGFILE 2>&1 || fail_with_info
-			if [ "" != "$FSBRANCH" ]; then
-				cd $i
-				git checkout $FSBRANCH >> $LOGFILE 2>&1
-				cd ..
-			fi			
-		else
-			cd $i
-			if [ "" != "$FSBRANCH" ]; then
-				git checkout $FSBRANCH >> $LOGFILE 2>&1
-			fi	
-			git remote update >> $LOGFILE 2>&1
-			git status -uno | grep -q behind
-			if [ 0 -eq $? ]; then
-				echo -e -n "Updating... "
-				git pull >> $LOGFILE 2>&1
-				make clean >> $LOGFILE 2>&1
-			fi
-			cd ..
-		fi
-		echo -e -n "Building... "
-		make -C $i >> $LOGFILE 2>&1 || fail_with_info
-		echo -e -n "Installing... "
-		make -C $i install >> $LOGFILE 2>&1 || fail_with_info
-		echo -e "Done"
-	done
+    for i in $filesystems
+    do
+        echo -e -n "$i: "
+        if [ ! -d $i ]; then
+            echo -e -n "Cloning... "
+            git clone https://github.com/Free60Project/$i.git  >> $LOGFILE 2>&1 || fail_with_info
+            if [ "" != "$FSBRANCH" ]; then
+                cd $i
+                git checkout $FSBRANCH >> $LOGFILE 2>&1
+                cd ..
+            fi			
+        else
+            cd $i
+            if [ "" != "$FSBRANCH" ]; then
+                git checkout $FSBRANCH >> $LOGFILE 2>&1
+            fi	
+            git remote update >> $LOGFILE 2>&1
+            git status -uno | grep -q behind
+            if [ 0 -eq $? ]; then
+                echo -e -n "Updating... "
+                git pull >> $LOGFILE 2>&1
+                make clean >> $LOGFILE 2>&1
+            fi
+            cd ..
+        fi
+        echo -e -n "Building... "
+        make -C $i >> $LOGFILE 2>&1 || fail_with_info
+        echo -e -n "Installing... "
+        make -C $i install >> $LOGFILE 2>&1 || fail_with_info
+        echo -e "Done"
+    done
 }
 
 bin2s_install()
 {
-	pushd ../libxenon/ports/xenon/
-	echo -e "Building bin2s..."
-	gcc bin2s.c -o bin2s || fail_with_info
-	echo -e "Installing bin2s..."
-	mv bin2s $DEVKITXENON/bin
-	chmod a+x $DEVKITXENON/bin/bin2s
-	echo -e "Done"
-	popd
+    pushd ../libxenon/ports/xenon/
+    echo -e "Building bin2s..."
+    gcc bin2s.c -o bin2s || fail_with_info
+    echo -e "Installing bin2s..."
+    mv bin2s $DEVKITXENON/bin
+    chmod a+x $DEVKITXENON/bin/bin2s
+    echo -e "Done"
+    popd
 }
 
 cube()
 {
-	rm -rf free60 &>/dev/null
-	rm cube.elf32 &>/dev/null
+    rm -rf free60 &>/dev/null
+    rm cube.elf32 &>/dev/null
 
-	#check if git is present to download and install libxenon
-	git &>/dev/null
-	RETVAL=$?
+    #check if git is present to download and install libxenon
+    git &>/dev/null
+    RETVAL=$?
 
-	if [ $RETVAL -eq 1 ]; then
-		echo -e "Building Cube Sample..."
-		make -C ../devkitxenon/examples/xenon/graphics/cube >> $LOGFILE 2>&1
-		cp ../devkitxenon/examples/xenon/graphics/cube/cube.elf32 .
-		echo
-		echo -e "cube.elf32 compiled, run it via xell"
-		echo		
-		
-	else
-		echo
-		echo -e "git is needed to download libxenon, install it and run this script again with \"libxenon\" as argument"
-		echo -e "If you are running debian/ubuntu : apt install git"
-		echo
-	fi
-	exit 0	
+    if [ $RETVAL -eq 1 ]; then
+        echo -e "Building Cube Sample..."
+        make -C ../devkitxenon/examples/xenon/graphics/cube >> $LOGFILE 2>&1
+        cp ../devkitxenon/examples/xenon/graphics/cube/cube.elf32 .
+        echo
+        echo -e "cube.elf32 compiled, run it via xell"
+        echo		
+        
+    else
+        echo
+        echo -e "git is needed to download libxenon, install it and run this script again with \"libxenon\" as argument"
+        echo -e "If you are running debian/ubuntu : apt install git"
+        echo
+    fi
+    exit 0	
 }
 
 all_done()
 {
-	RED='\e[0;31m'
-	NC='\e[0m'
+    RED='\e[0;31m'
+    NC='\e[0m'
 
-	echo
-	echo -e "All done, your xenon toolchain is located here : $PREFIX"
-	echo
-	echo -e "${RED}Please add the following path to your login script (~/.bashrc) if you'd like every shell to have access by default:"
-	echo
-	echo -e "export DEVKITXENON=$PREFIX"
-	echo -e 'export PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"'
+    echo
+    echo -e "All done, your xenon toolchain is located here : \"$PREFIX"\"
+    echo
+    echo -e "${RED}Please add the following path to your login script (~/.bashrc) if you'd like every shell to have access by default:"
+    echo
+    echo -e "export DEVKITXENON=\"$PREFIX"\"
+    echo -e 'export PATH="${PATH:+${PATH}:}"$DEVKITXENON"/bin:"$DEVKITXENON"/usr/bin"'
     echo 
     echo -e "Alternatively, run "$0" env-cmd to install a command named xenon-env to /usr/local/bin/xenon-env to set those in the current shell for you"
-	echo -e "${NC}"
+    echo -e "${NC}"
 }
 
 # start
 rm -f $LOGFILE
 
 if [ "$1" == "toolchain" ]; then
-    echo "Info: root privilages are required to install dependencies."
+
+    if command -v apt > /dev/null || command -v dnf > /dev/null; then
+        echo "Info: a package manager has been detected. Root privilages are required to install dependencies."
+    fi
 
     if command -v apt-get &> /dev/null; then
-		sudo apt install -y build-essential flex bison gcc-multilib
+        sudo apt install -y build-essential flex bison gcc-multilib libgmp-dev libmpfr-dev libmpc-dev texinfo git wget
     elif command -v dnf &> /dev/null; then
-        sudo dnf -y install flex bison glibc-devel.i686 libstdc++-devel.i686 gmp-devel mpfr-devel libmpc-devel texinfo git-core gcc g++ wget
+        sudo dnf -y install gcc g++ flex bison glibc-devel.i686 libstdc++-devel.i686 gmp-devel mpfr-devel libmpc-devel texinfo git wget
+    else
+        echo "Info: a package manager was not detected. Ensure that the required dependencies have been installed."
     fi
     
     toolchain_install "$0" "$@"
-    libxenon_install "$0" "$@"
     all_done
 elif [ "$1" == "libs" ]; then
     zlib_install "$0" "$@"
@@ -480,14 +483,13 @@ elif [ "$1" == "clean" ]; then
     rm -rf xtaflib
     make -C ../devkitxenon/examples/xenon/graphics/cube clean
 elif [ "$1" == "env-cmd" ]; then
-    echo "Info: root privilages are required to install xenon-env to /usr/local/bin"
-    rm -f /usr/local/bin/xenon-env
-	echo -e '#!/bin/bash\n'export DEVKITXENON=$DEVKITXENON'\nexport PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"\necho $PATH\nbash\n' | sudo tee -a /usr/local/bin/xenon-env
-	sudo chmod 755 /usr/local/bin/xenon-env
+    check_priv "$0" "$@"
+    echo -e '#!/bin/bash\n'export DEVKITXENON=\""$DEVKITXENON"\"'\nexport PATH="${PATH:+${PATH}:}"$DEVKITXENON"/bin:"$DEVKITXENON"/usr/bin"\necho $PATH\nbash\n' > /usr/local/bin/xenon-env
+    chmod 755 /usr/local/bin/xenon-env
     echo "Run the xenon-env command to add libxenon to your curent shell PATH."
 else
     echo -e "Usage:"
-    echo -e "\"$0 toolchain\" (install toolchain + libxenon)"
+    echo -e "\"$0 toolchain\" (install toolchain)"
     echo -e "\"$0 libs\" (install libxenon + bin2s + libraries seen below)"
     echo -e "\"$0 libxenon\" (install or update libxenon)"
     echo -e "\"$0 zlib\" (install or update zlib)"

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -4,18 +4,26 @@
 # changed for xenon by Felix Domke <tmbinc@elitedvb.net>, still public domain
 
 TARGET=xenon
-PREFIX=${PREFIX:-/usr/local/xenon} # Install location of your final toolchain
+PREFIX=${PREFIX:-/usr/local/xenon} # Install location of your final toolchain. Never quoted because gcc fails to install to such things
 PARALLEL=
 
-BINUTILS=binutils-2.32
-GCC=gcc-9.2.0
-NEWLIB=newlib-3.1.0
-GDB=gdb-6.8
+BINUTILS_DL="https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.gz"
+GCC_DL="https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz"
+NEWLIB_DL="https://sourceware.org/pub/newlib/newlib-3.1.0.tar.gz"
 
-ZLIB=zlib-1.2.11
-LIBPNG=libpng-1.5.10
-BZIP2=bzip2-1.0.6
-FREETYPE=freetype-2.10.4
+ZLIB_DL="https://zlib.net/fossils/zlib-1.2.11.tar.gz"
+LIBPNG_DL="https://download.sourceforge.net/libpng/libpng-1.5.10.tar.xz"
+BZIP2_DL="https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz"
+FREETYPE_DL="https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz"
+
+BINUTILS=$(basename $BINUTILS_DL .tar.gz)
+GCC=$(basename $GCC_DL .tar.gz)
+NEWLIB=$(basename $NEWLIB_DL .tar.gz)
+
+ZLIB=$(basename $ZLIB_DL .tar.gz)
+LIBPNG=$(basename $LIBPNG_DL .tar.xz)
+BZIP2=$(basename $BZIP2_DL .tar.gz)
+FREETYPE=$(basename $FREETYPE_DL .tar.gz)
 
 # build stages
 BUILD_BINUTILS=true
@@ -27,161 +35,180 @@ BUILD_GCC_SECOND=true
 EXTR=cat
 if type "pv" &> /dev/null; then
   EXTR=pv
-fi;
+fi
 
+cd "$(dirname "$0")"
 #FSBRANCH=Swizzy
 
 # path to the logfile
-LOGFILE="`pwd`/build.log"
+LOGFILE=build.log
 
-# temp variables export
-export DEVKITXENON="$PREFIX"
-export PATH="$PATH:$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
+# temp variables export, same as xenon-env cmd does
+export DEVKITXENON=$PREFIX
+export PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"
 
-function fail_with_info()
+check_priv()
+{
+    # test if we can install stuff to $PREFIX
+    if [ "$EUID" -ne 0 ]; then
+        mkdir -p $PREFIX
+        touch $PREFIX/check_priv 2>/dev/null
+
+        if [ ! -f $PREFIX/check_priv ]; then
+            echo "For your selected prefix ($PREFIX), root privileges are required:"
+            sudo "$@"
+            rm -f $PREFIX/check_priv
+            exit 0
+        fi
+
+        rm -f $PREFIX/check_priv
+        return
+    fi    
+}
+
+fail_with_info()
 {
 	echo "[-] Script failed, check build.log!" >> /dev/stderr
 	exit 1
 }
 
-# function to compile and install libxenon
-function libxenon_install
+# to compile and install libxenon
+libxenon_install()
 {
-        echo -e "Building libxenon..."
-        make -C ../libxenon/ports/xenon clean 2>&1 >> $LOGFILE || fail_with_info
-        make $PARALLEL -C ../libxenon/ports/xenon libxenon.a 2>&1 >> $LOGFILE || fail_with_info
-        make -C ../libxenon/ports/xenon install 2>&1 >> $LOGFILE || fail_with_info
-        echo
-        echo -e "libxenon installed successfully"
-        echo
+    check_priv "$@"
+    echo -e "Building libxenon..."
+    make -C ../libxenon/ports/xenon clean 2>&1 >> $LOGFILE || fail_with_info
+    make $PARALLEL -C ../libxenon/ports/xenon libxenon.a 2>&1 >> $LOGFILE || fail_with_info
+    make -C ../libxenon/ports/xenon install 2>&1 >> $LOGFILE || fail_with_info
+    echo
+    echo -e "libxenon installed successfully"
+    echo
 }
 
-function toolchain_install
+toolchain_install()
 {
-        BINUTILS_FILE="${BINUTILS}.tar.gz"
-        GCC_FILE="${GCC}.tar.gz"
-        NEWLIB_FILE="${NEWLIB}.tar.gz"
+    check_priv "$@"
+    chown -R `whoami`:`whoami` $PREFIX
 
-        # Make working directory
-        echo -e "Creating final xenon toolchain directory: $PREFIX"
-        if [ ! -d $PREFIX ]; then
-                mkdir $PREFIX
-                chown -R `whoami`:`whoami` $PREFIX
-        fi;
+    # Check if binutils sources are available, download it if needed
+    if [ ! -f $BINUTILS.tar.gz ]; then
+            echo -e "Downloading $BINUTILS"
+            wget -c $BINUTILS_DL || fail_with_info
+    fi
 
-        # Check if binutils sources are available, download it if needed
-        if [ ! -f $BINUTILS_FILE ]; then
-                echo -e "Downloading $BINUTILS_FILE"
-                wget -c http://ftp.gnu.org/gnu/binutils/$BINUTILS_FILE || fail_with_info
-        fi;
+    # Check if gcc sources are available, download it if needed
+    if [ ! -f $GCC.tar.gz ]; then
+            echo -e "Downloading $GCC"
+            wget -c $GCC_DL || fail_with_info
+    fi
 
-        # Check if gcc sources are available, download it if needed
-        if [ ! -f $GCC_FILE ]; then
-                echo -e "Downloading $GCC_FILE"
-                wget -c ftp://ftp.gnu.org/gnu/gcc/$GCC/$GCC_FILE || fail_with_info
-        fi;
+    # Check if newlib sources are available, download it if needed
+    if [ ! -f $NEWLIB.tar.gz ]; then
+            echo -e "Downloading $NEWLIB"
+            wget -c $NEWLIB_DL || fail_with_info
+    fi
 
-        # Check if newlib sources are available, download it if needed
-        if [ ! -f $NEWLIB_FILE ]; then
-                echo -e "Downloading $NEWLIB_FILE"
-                wget -c ftp://sourceware.org/pub/newlib/$NEWLIB_FILE || fail_with_info
-        fi;
+    rm -rf build
+    mkdir build
 
-        rm -rf build
-        mkdir build
-
-        if $BUILD_BINUTILS; then
-          if [ ! -d $BINUTILS ]; then
+    if $BUILD_BINUTILS; then
+        if [ ! -d $BINUTILS ]; then
             mkdir $BINUTILS
-            echo -e "Extracting binutils..."
-            $EXTR $BINUTILS_FILE | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
+            echo -e "Extracting $BINUTILS..."
+            $EXTR $BINUTILS.tar.gz | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
             cat $BINUTILS.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
 
             if [ -f $BINUTILS-vmx128.diff ]; then
-              echo -e "Applying vmx128 support..."
-              cat $BINUTILS-vmx128.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
-            fi;
-          fi;
-          cd build
-          echo -e "Configuring binutils..."
-          ../$BINUTILS/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls --disable-werror >> $LOGFILE 2>&1 || fail_with_info
-          echo -e "Building binutils, this could take a while..."
-          make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
-          make install 2>&1 >> $LOGFILE || fail_with_info
-          cd ..
-          rm -rf build/*;
-          echo -e "Done"
-        fi;
-
-        if $BUILD_GCC; then
-          if [ ! -d $GCC ]; then
-            mkdir $GCC
-            echo -e "Extracting gcc..."
-            $EXTR $GCC_FILE | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
-            cat $GCC.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
-          fi;
-          cd build
-          echo -e "Configuring gcc..."
-          ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local -enable-interwork \
-                  --enable-languages="c" --without-headers --disable-shared \
-                  --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
-                  --disable-decimal-float --enable-altivec \
-                  --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
-          echo -e "Building gcc, this could take a while..."
-          make $PARALLEL all-gcc 2>&1 >> $LOGFILE || fail_with_info
-          make install-gcc 2>&1 >> $LOGFILE || fail_with_info
-          cd ..
-          rm -rf build/*
-          echo -e "Done"
-        fi;
-
-        if $BUILD_NEWLIB; then
-          mkdir -p $NEWLIB
-          echo -e "Extracting newlib..."
-          $EXTR $NEWLIB_FILE | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
-          cat $NEWLIB.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
-          cd build
-          echo -e "Configuring newlib..."
-          ../$NEWLIB/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls \
-            CFLAGS="-DHAVE_BLKSIZE -O2"\
-            --enable-newlib-io-long-long --enable-newlib-io-long-double >> $LOGFILE 2>&1 || fail_with_info
-          echo -e "Building newlib, this could take a while..."
-          make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
-          make install 2>&1 >> $LOGFILE || fail_with_info
-          cd ..
-          #rm -rf build/*
-          echo -e "Done"
+                echo -e "Applying vmx128 support..."
+                cat $BINUTILS-vmx128.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
+            fi
         fi
+        cd build
+        echo -e "Configuring $BINUTILS..."
+        ../$BINUTILS/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls --disable-werror >> $LOGFILE 2>&1 || fail_with_info
+        echo -e "Building $BINUTILS, this could take a while..."
+        make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
+        echo -e "Installing $BINUTILS..."
+        make install 2>&1 >> $LOGFILE || fail_with_info
+        cd ..
+        rm -rf build/*
+        echo -e "Done"
+    fi
 
-        if $BUILD_GCC_SECOND; then
-          # Yes, you need to build gcc again!
-          cd build
-          echo -e "Configuring gcc - 2nd pass..."
-          unset LIBRARY_PATH
-          ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local --with-cpu=cell \
-                  --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
-                  --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
-                  --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
-                  --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
-          echo -e "Building gcc - 2nd pass, this could take a while..."
-          make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
-          make install 2>&1 >> $LOGFILE || fail_with_info
-          cd ..
-          rm -rf build/*
-          echo -e "Done"
+    if $BUILD_GCC; then
+        if [ ! -d $GCC ]; then
+        mkdir $GCC
+        echo -e "Extracting $GCC..."
+        $EXTR $GCC.tar.gz | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
+        cat $GCC.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
         fi
+        cd build
+        echo -e "Configuring $GCC..."
+        ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local -enable-interwork \
+                --enable-languages="c" --without-headers --disable-shared \
+                --with-newlib --disable-libmudflap --disable-libssp --disable-nls --disable-shared --without-headers \
+                --disable-decimal-float --enable-altivec \
+                --with-gmp=/opt/local --with-mpfr=/opt/local --with-cpu=cell >> $LOGFILE 2>&1 || fail_with_info
+        echo -e "Building $GCC, this could take a while..."
+        make $PARALLEL all-gcc 2>&1 >> $LOGFILE || fail_with_info
+        echo -e "Installing $GCC..."
+        make install-gcc 2>&1 >> $LOGFILE || fail_with_info
+        cd ..
+        rm -rf build/*
+        echo -e "Done"
+    fi
 
-        rm -rf build
+    if $BUILD_NEWLIB; then
+        mkdir -p $NEWLIB
+        echo -e "Extracting $NEWLIB..."
+        $EXTR $NEWLIB.tar.gz | tar xfz - >> $LOGFILE 2>&1 || fail_with_info
+        cat $NEWLIB.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
+        cd build
+        echo -e "Configuring $NEWLIB..."
+        ../$NEWLIB/configure --target=$TARGET --prefix=$PREFIX  --enable-multilib --disable-nls \
+        CFLAGS="-DHAVE_BLKSIZE -O2"\
+        --enable-newlib-io-long-long --enable-newlib-io-long-double >> $LOGFILE 2>&1 || fail_with_info
+        echo -e "Building $NEWLIB, this could take a while..."
+        make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
+        echo -e "Installing $NEWLIB..."
+        make install 2>&1 >> $LOGFILE || fail_with_info
+        cd ..
+        #rm -rf build/*
+        echo -e "Done"
+    fi
+
+    if $BUILD_GCC_SECOND; then
+        # Yes, you need to build gcc again!
+        cd build
+        echo -e "Configuring $GCC (2nd pass)..."
+        unset LIBRARY_PATH
+        ../$GCC/configure --target=$TARGET --prefix=$PREFIX --with-libiconv-prefix=/opt/local --with-cpu=cell \
+                --with-gmp=/opt/local --with-mpfr=/opt/local --disable-decimal-float --disable-libquadmath \
+                --enable-languages=c,c++ --disable-libssp --disable-libsanitizer --with-newlib --enable-cxx-flags="-G0" \
+                --disable-libmudflap --disable-nls --disable-shared --disable-linux-futex --enable-altivec \
+                --disable-libatomic --disable-threads --disable-libgomp --disable-libitm -v >> $LOGFILE 2>&1 || fail_with_info
+        echo -e "Building $GCC - (2nd pass), this could take a while..."
+        make $PARALLEL 2>&1 >> $LOGFILE || fail_with_info
+        echo -e "Installing $GCC (2nd pass)..."
+        make install 2>&1 >> $LOGFILE || fail_with_info
+        cd ..
+        rm -rf build/*
+        echo -e "Done"
+    fi
+
+    rm -rf build
 }
 
-function zlib_install
+zlib_install()
 {
-	if [ ! -f "$ZLIB.tar.gz" ]; then
-		echo -e "Downloading $ZLIB.tar.gz"
-		wget -c http://zlib.net/fossils/$ZLIB.tar.gz || fail_with_info
-	fi;
+    check_priv "$@"
 
-	echo -e "Extracting zlib..."
+	if [ ! -f "$ZLIB.tar.gz" ]; then
+		echo -e "Downloading $ZLIB..."
+		wget -c $ZLIB_DL || fail_with_info
+	fi
+
+	echo -e "Extracting $ZLIB..."
 	rm -rf $ZLIB
 	tar xzf $ZLIB.tar.gz >> $LOGFILE 2>&1 || fail_with_info
 	cd $ZLIB
@@ -192,14 +219,14 @@ function zlib_install
 	export LDFLAGS="$CFLAGS"
 	export TARGET=`gcc -v 2>&1 | sed -n '2p' | awk '{print $2}'`
 
-	echo -e "Configuring zlib..."
+	echo -e "Configuring $ZLIB..."
 	./configure --prefix=$DEVKITXENON/usr >> $LOGFILE 2>&1 || fail_with_info
 
 	sed '/cp $(SHAREDLIBV) $(DESTDIR)$(sharedlibdir)/d' Makefile > Makefile.xenon
 
-	echo -e "Building zlib..."
+	echo -e "Building $ZLIB..."
 	make $PARALLEL -f Makefile.xenon CROSS_COMPILE=$TARGET- libz.a >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing zlib..."
+	echo -e "Installing $ZLIB..."
 	make -f Makefile.xenon CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
 	cd ..
 	rm -rf $ZLIB
@@ -212,14 +239,16 @@ function zlib_install
 	echo -e "Done"
 }
 
-function libpng_install
+libpng_install()
 {
-	if [ ! -f "$LIBPNG.tar.xz" ]; then
-		echo -e "Downloading $LIBPNG.tar.xz"
-		wget -c http://download.sourceforge.net/libpng/$LIBPNG.tar.xz || fail_with_info
-	fi;
+    check_priv "$@"
 
-	echo -e "Extracting libpng..."
+	if [ ! -f "$LIBPNG.tar.xz" ]; then
+		echo -e "Downloading $LIBPNG..."
+		wget -c $LIBPNG_DL || fail_with_info
+	fi
+
+	echo -e "Extracting $LIBPNG..."
 	rm -rf $LIBPNG
 	tar xJf $LIBPNG.tar.xz >> $LOGFILE 2>&1 || fail_with_info
 	cd $LIBPNG
@@ -228,52 +257,56 @@ function libpng_install
 	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32 -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
 	export LDFLAGS="$CFLAGS"
 
-	echo -e "Configuring libpng..."
+	echo -e "Configuring $LIBPNG..."
 	./configure --disable-shared --enable-static --prefix=$DEVKITXENON/usr --host=ppc-elf >> $LOGFILE 2>&1 || fail_with_info
 
-	echo -e "Building libpng..."
+	echo -e "Building $LIBPNG..."
 	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing libpng..."	
+	echo -e "Installing $LIBPNG..."	
 	make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
 	cd ..
 	rm -rf $LIBPNG
 
-        export CC=""
-        export CFLAGS=""
-        export LDFLAGS=""
+    export CC=""
+    export CFLAGS=""
+    export LDFLAGS=""
 
 	echo -e "Done"
 }
 
-function bzip2_install
+bzip2_install()
 {
-	if [ ! -f "$BZIP2.tar.gz" ]; then
-		echo -e "Downloading $BZIP2.tar.gz"
-		wget -c ftp://sourceware.org/pub/bzip2/$BZIP2.tar.gz || fail_with_info
-	fi;
+    check_priv "$@"
 
-	echo -e "Extracting bzip2..."
+	if [ ! -f "$BZIP2.tar.gz" ]; then
+		echo -e "Downloading $BZIP2..."
+		wget -c $BZIP2_DL || fail_with_info
+	fi
+
+	echo -e "Extracting $BZIP2..."
 	rm -rf $BZIP2
 	tar xzf $BZIP2.tar.gz >> $LOGFILE 2>&1 && cat ../libxenon/ports/bzip2/$BZIP2.diff | patch -p0 >> $LOGFILE 2>&1 || fail_with_info
 	cd $BZIP2
 
-	echo -e "Building bzip2..."
+	echo -e "Building $BZIP2..."
 	make $PARALLEL >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing bzip2..."
+	echo -e "Installing $BZIP2..."
 	make install >> $LOGFILE 2>&1 || fail_with_info
 	cd ..
 	rm -rf $BZIP2
 	echo -e "Done"
 }
 
-function freetype_install
+freetype_install()
 {
+    check_priv "$@"
+
 	if [ ! -f "$FREETYPE.tar.gz" ]; then
-		echo -e "Downloading $FREETYPE.tar.gz"
-		wget -c http://download.savannah.gnu.org/releases/freetype/$FREETYPE.tar.gz || fail_with_info
-	fi;
+		echo -e "Downloading $FREETYPE..."
+		wget -c $FREETYPE_DL || fail_with_info
+	fi
 	
-	echo -e "Extracting freetype..."
+	echo -e "Extracting $FREETYPE..."
 	rm -rf $FREETYPE
 	tar xzf $FREETYPE.tar.gz >> $LOGFILE 2>&1 || fail_with_info
 	cd $FREETYPE
@@ -282,12 +315,12 @@ function freetype_install
 	export CFLAGS="-mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 $DEVKITXENON/usr/lib/libxenon.a -L$DEVKITXENON/xenon/lib/32/ -T$DEVKITXENON/app.lds -u read -u _start -u exc_base -L$DEVKITXENON/usr/lib -I$DEVKITXENON/usr/include"
 	export LDFLAGS="$CFLAGS"
 
-	echo -e "Configuring freetype..."
+	echo -e "Configuring $FREETYPE..."
 	./configure --prefix=$DEVKITXENON/usr --host=ppc-elf --disable-shared --without-brotli >> $LOGFILE 2>&1 || fail_with_info
 
-	echo -e "Building freetype..."
+	echo -e "Building $FREETYPE..."
 	make $PARALLEL CROSS_COMPILE=$TARGET- >> $LOGFILE 2>&1 || fail_with_info
-	echo -e "Installing freetype..."
+	echo -e "Installing $FREETYPE..."
 	make CROSS_COMPILE=$TARGET- install >> $LOGFILE 2>&1 || fail_with_info
 	cd ..
 	rm -rf $FREETYPE
@@ -299,8 +332,9 @@ function freetype_install
 	echo -e "Done"
 }
 
-function filesystems_install
+filesystems_install()
 {
+    check_priv "$@"
 	echo -e "Building Filesystems..."
 
 	filesystems="fat-xenon ext2fs-xenon xtaflib" # ntfs-xenon ext2fs-xenon xtaflib
@@ -338,7 +372,7 @@ function filesystems_install
 	done
 }
 
-function bin2s_install
+bin2s_install()
 {
 	pushd ../libxenon/ports/xenon/
 	echo -e "Building bin2s..."
@@ -350,7 +384,7 @@ function bin2s_install
 	popd
 }
 
-function cube
+cube()
 {
 	rm -rf free60 &>/dev/null
 	rm cube.elf32 &>/dev/null
@@ -376,7 +410,7 @@ function cube
 	exit 0	
 }
 
-function all_done
+all_done()
 {
 	RED='\e[0;31m'
 	NC='\e[0m'
@@ -384,86 +418,73 @@ function all_done
 	echo
 	echo -e "All done, your xenon toolchain is located here : $PREFIX"
 	echo
-	echo -e "${RED}Please add the following path to your login script (~/.bashrc)"
+	echo -e "${RED}Please add the following path to your login script (~/.bashrc) if you'd like every shell to have access by default:"
 	echo
-	echo -e "export DEVKITXENON=\"$PREFIX\""
-	echo -e "export PATH=\"\$PATH:\$DEVKITXENON/bin:\$DEVKITXENON/usr/bin\""
+	echo -e "export DEVKITXENON=$PREFIX"
+	echo -e 'export PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"'
+    echo 
+    echo -e "Alternatively, run "$0" env-cmd to install a command named xenon-env to /usr/local/bin/xenon-env to set those in the current shell for you"
 	echo -e "${NC}"
 }
 
-function check_build-essential
-{
-	echo -e "Ubuntu or Debian is detected."
-	dpkg -s build-essential >> $LOGFILE 2>&1
-
-	if [ $? -eq 1 ]; then
-		echo -e "The build-essential package was not detected on your system"
-		echo -e "To build the toolchain you need to download and install the build-essential package."
-		echo -e "Do you want this script to do it for you ? (y/n)"
-		read answer >> $LOGFILE 2>&1
-		if [ "$answer" == "y" ]; then
-			echo -e "Please wait while installing build-essential..."
-			apt install -y build-essential >> $LOGFILE 2>&1
-		fi
-	else
-		echo -e "The build-essential package was detected on your system"
-	fi
-
-	dpkg -s flex bison >> $LOGFILE 2>&1
-	if [ $? -eq 1 ]; then
-		echo -e "Flex / Bison were not detected on your system (binutils)"
-		echo -e "Do you want this script to attempt to install them for you? (y/n)"
-		read answer >> $LOGFILE 2>&1
-		if [ "$answer" == "y" ]; then
-			echo -e "Please wait while installing flex and bison..."
-			apt install -y flex bison >> $LOGFILE 2>&1
-		fi
-	fi;
-
-	dpkg -s gcc-multilib >> $LOGFILE 2>&1
-	if [ $? -eq 1 ]; then
-		echo -e "gcc-multilib was not detected on your system (binutils)"
-		echo -e "Do you want this script to attempt to install it for you? (y/n)"
-		read answer >> $LOGFILE 2>&1
-		if [ "$answer" == "y" ]; then
-			echo -e "Please wait while installing gcc-multilib..."
-			apt install -y gcc-multilib >> $LOGFILE 2>&1
-		fi
-	fi;
-}
-
 # start
-rm $LOGFILE &>/dev/null
+rm -f $LOGFILE
 
 if [ "$1" == "toolchain" ]; then
+    echo "Info: root privilages are required to install dependencies."
+
     if command -v apt-get &> /dev/null; then
-		check_build-essential
+		sudo apt install -y build-essential flex bison gcc-multilib
+    elif command -v dnf &> /dev/null; then
+        sudo dnf -y install flex bison glibc-devel.i686 libstdc++-devel.i686 gmp-devel mpfr-devel libmpc-devel texinfo git-core gcc g++ wget
     fi
-    toolchain_install
+    
+    toolchain_install "$0" "$@"
+    libxenon_install "$0" "$@"
     all_done
 elif [ "$1" == "libs" ]; then
-    zlib_install
-    bzip2_install
-    libpng_install
-    freetype_install
-    bin2s_install
-    filesystems_install
+    zlib_install "$0" "$@"
+    bzip2_install "$0" "$@"
+    libpng_install "$0" "$@"
+    freetype_install "$0" "$@"
+    bin2s_install "$0" "$@"
+    filesystems_install "$0" "$@"
 elif [ "$1" == "libxenon" ]; then
-    libxenon_install
+    libxenon_install "$0" "$@"
 elif [ "$1" == "zlib" ]; then
-    zlib_install
+    zlib_install "$0" "$@"
 elif [ "$1" == "libpng" ]; then
-    libpng_install
+    libpng_install "$0" "$@"
 elif [ "$1" == "bzip2" ]; then
-    bzip2_install
+    bzip2_install "$0" "$@"
 elif [ "$1" == "freetype" ]; then
-    freetype_install
+    freetype_install "$0" "$@"
 elif [ "$1" == "filesystems" ]; then
-    filesystems_install
+    filesystems_install "$0" "$@"
 elif [ "$1" == "bin2s" ]; then
-        bin2s_install
+    bin2s_install "$0" "$@"
 elif [ "$1" == "cube" ]; then
     cube
+elif [ "$1" == "clean" ]; then
+    check_priv "$0" "$@"
+    rm -rf $GCC $GCC.tar.gz
+    rm -rf $BINUTILS $BINUTILS.tar.gz
+    rm -rf $NEWLIB $NEWLIB.tar.gz
+    rm -rf $ZLIB $ZLIB.tar.gz
+    rm -rf $LIBPNG $LIBPNG.tar.xz
+    rm -rf $BZIP2 $BZIP2.tar.gz
+    rm -rf $FREETYPE $FREETYPE.tar.gz
+    rm -rf build
+    rm -rf ext2fs-xenon
+    rm -rf fat-xenon
+    rm -rf xtaflib
+    make -C ../devkitxenon/examples/xenon/graphics/cube clean
+elif [ "$1" == "env-cmd" ]; then
+    echo "Info: root privilages are required to install xenon-env to /usr/local/bin"
+    rm -f /usr/local/bin/xenon-env
+	echo -e '#!/bin/bash\n'export DEVKITXENON=$DEVKITXENON'\nexport PATH="${PATH:+${PATH}:}$DEVKITXENON/bin:$DEVKITXENON/usr/bin"\necho $PATH\nbash\n' | sudo tee -a /usr/local/bin/xenon-env
+	sudo chmod 755 /usr/local/bin/xenon-env
+    echo "Run the xenon-env command to add libxenon to your curent shell PATH."
 else
     echo -e "Usage:"
     echo -e "\"$0 toolchain\" (install toolchain + libxenon)"
@@ -475,6 +496,8 @@ else
     echo -e "\"$0 freetype\" (install or update freetype)"
     echo -e "\"$0 filesystems\" (install libxenon filesystems)"
     echo -e "\"$0 cube\" (compile the cube sample)"
+    echo -e "\"$0 env-cmd\" (install a command to set env vars named xenon-env to /usr/local/bin)"
+    echo -e "\"$0 clean\" (delete all downloaded files)"
     echo
     exit 0
-fi;
+fi


### PR DESCRIPTION
I recently have wanted to compile xell-reloaded in order to get it working on my Winchester console via BadUpdate, launched via Aurora or the FreeMyXe built-in option.

I use Fedora Linux, which believe it or not does not enable the FTP protocol in the official wget available in the package manager. This led to the `build-xenon-toolchain` script failing on modern Fedora/Red Hat systems.

What started as a "change ftp: to http: or https: where applicable" ended up spiraling into a ton of improvements I could make to this script personally due to experience in such things such as [psn00bsdk-builder](https://github.com/alex-free/psn00bsdk-builder/tree/master) for the PS1, listed below:

* Uses https or http for all downloads, to work around the idiotic removal of the FTP protocol from the package manager obtained wget command in current Fedora Linux that will get into RHEL and other RedHat distros soon.

* Checks if the desired `$PREFIX` is writable at the current privilege level (i.e. if you need sudo to write to /usr/local/libxenon, it detects this. In such a case where the user needs root privileges but does not have them, it informs the user before re-running the `build -xenon-toolchain` script with the same arguments given originally, but under the sudo command).

* Ensures that the directory that `build-xenon-toolchain` is in will be changed into by the script. This allows you to run i.e. `libxenon/toolchain/build-xenon-toolchain` and have it work as expected.

* Better `$PATH` handling.

* Removed mentions/doing quotes around $PREFIX, since in practice you can't successfully use something with spaces with gcc and whatnot so it was never necessary.

* Automatically install dependencies for both `apt` and `dnf` package managers. Before doing so, it does inform the user that root privileges are required for that part of the script only. This still allows a user to install to a non-root privileged $PREFIX for instance. This covers both RedHat and Debian based distros by default, and other things like Arch can be added easily in the same way that I did this for `dnf`.

* Provides a new argument, `clean` which deletes all downloaded files from the source tree. The extracted equivalents are also removed.

* Provides a new argument, `env-cmd`. This installs a command named `xenon-env` which sets the env vars in the current shell. This allows people like me to not need to modify ~/.bashrc which can be messy to some. Instead, the user gets a specific shell instance that is automatically changed into with specific env vars by the command, to not affect anything else on their system.

* I changed up the whole format of how downloaded files are handled. I think you should specify the URL once at the beginning of the script and then script should modify that var for the user as it needs. This is much better for URL maintenance  and future proofing.

* The `toolchain` argument specifies that it will install both the toolchain and libxenon, but in practice it was not installing libxenon. I fixed this so that it matches the expected behavior mentioned when executing `./build-xenon-toolchain` with no/wrong args.

* Formatted some weird spacing to 4 space tabs.

* Cleaned up bash function syntax (no function keyword, added brackets to the end of each).

* Lastly, due to the addition of the `clean` argument I properly implemented the external deps (i.e. libpng) as variables to keep track of them.

