### PR TITLE
Add support for vfuses on consoles running DevGL images

### DIFF
--- a/libxenon/drivers/xb360/xb360.c
+++ b/libxenon/drivers/xb360/xb360.c
@@ -101,21 +101,39 @@ int cpu_get_key(unsigned char *data)
 
 int get_virtual_cpukey(unsigned char *data)
 {
-  unsigned char buffer[VFUSES_SIZE];
+   unsigned char buffer[VFUSES_SIZE];
 
-  if (xenon_get_logical_nand_data(&buffer, VFUSES_OFFSET, VFUSES_SIZE == -1))
-	  return 2; //Unable to read NAND data...
+   if (xenon_get_logical_nand_data(&buffer, VFUSES_OFFSET, VFUSES_SIZE) == -1)
+   {
+         return 2; //Unable to read NAND data...
+   }
 
-  //if we got here then it was at least able to read from nand
-  //now we need to verify the data somehow
-  if (buffer[0]==0xC0 && buffer[1]==0xFF && buffer[2]==0xFF && buffer[3]==0xFF)
-  {
-	memcpy(data,&buffer[0x20],0x10);
-    	return 0;
-  }
-  else
-	/* No Virtual Fuses were found at 0x95000*/
-	return 1;
+   //if we got here then it was at least able to read from nand
+   //now we need to verify the data somehow
+   if(buffer[0]==0xC0 && buffer[1]==0xFF && buffer[2]==0xFF && buffer[3]==0xFF)
+   {
+      memcpy(data,&buffer[0x20],0x10);
+      return 0;
+   }
+   else
+   {
+      // No Virtual Fuses were found at 0x95000, check again at 0xC0000 (Zero fuse DevGL consoles)
+      if (xenon_get_logical_nand_data(&buffer, ZFUSES_OFFSET, VFUSES_SIZE) == -1)
+      {
+         return 2; //Unable to read NAND data...
+      }
+
+      //if we got here then it was at least able to read from nand
+      //now we need to verify the data somehow
+      if(buffer[0]==0xC0 && buffer[1]==0xFF && buffer[2]==0xFF && buffer[3]==0xFF)
+      {
+         memcpy(data,&buffer[0x20],0x10);
+         return 0;
+      }
+
+      // No virtual fuses at 0x95000 or 0xC0000
+      return 1;
+   }
 }
 
 

--- a/libxenon/drivers/xb360/xb360.h
+++ b/libxenon/drivers/xb360/xb360.h
@@ -74,7 +74,7 @@ unsigned int xenon_get_kv_offset();
 #define KV_FLASH_PTR              0x6C
 #define VFUSES_SIZE               0x60
 #define VFUSES_OFFSET			  0x95000
-
+#define ZFUSES_OFFSET           0xC0000
 #define XELL_SIZE (256*1024)
 #define XELL_FOOTER_OFFSET (256*1024-16)
 #define XELL_FOOTER_LENGTH 16


### PR DESCRIPTION
Current vfuse code in libxenon looks at 0x95000. On zero fuse consoles running DevGL images, the vfuses are stored at 0xC0000 instead. This PR adds code to get_virtual_cpukey to check 0xC0000 if we don't find vfuses at 0x95000

Tested on my zero fuse jasper console, am able to decrypt the KV as expected.

![IMG_0564](https://github.com/user-attachments/assets/6d717c0b-ddb0-4c5b-928a-4fc7bce55e1c)
