### PR TITLE
Draft: New input APIs to get controller type (Guitar, Wheel, etc)

### DIFF
--- a/libxenon/drivers/input/input.c
+++ b/libxenon/drivers/input/input.c
@@ -2,6 +2,7 @@
 
 static struct controller_data_s ctrl[4];
 static int valid[4];
+static int ctrl_type[4];
 
 int get_controller_data(struct controller_data_s *d, int port)
 {
@@ -19,6 +20,20 @@ void set_controller_data(int port, const struct controller_data_s *d)
 		return;
 	ctrl[port] = *d;
 	valid[port] = 1;
+}
+
+int get_controller_type(int port)
+{
+	if (port >= 4)
+		return 0;
+	return ctrl_type[port];
+}
+
+void set_controller_type(int port, int type)
+{
+	if (port >= 4)
+		return;
+	ctrl_type[port] = type;
 }
 
 extern int usbctrl_set_rumble(int port, uint8_t l, uint8_t r);

--- a/libxenon/drivers/input/input.h
+++ b/libxenon/drivers/input/input.h
@@ -7,6 +7,18 @@
 
 #include <stdint.h>
 
+#define CTRL_TYPE_NONE 0x0
+#define CTRL_TYPE_GAMEPAD 0x1
+#define CTRL_TYPE_WHEEL 0x2
+#define CTRL_TYPE_ARCADE 0x3
+#define CTRL_TYPE_FLIGHT 0x4
+#define CTRL_TYPE_DANCE 0x5
+#define CTRL_TYPE_GUITAR 0x6
+#define CTRL_TYPE_GUITAR_ALT 0x7
+#define CTRL_TYPE_DRUMS 0x8
+#define CTRL_TYPE_GUITAR_BASS 0xB
+#define CTRL_TYPE_ARCADE_PAD 0x13
+
 struct controller_data_s
 {
 	signed short s1_x, s1_y, s2_x, s2_y;
@@ -18,6 +30,10 @@ struct controller_data_s
 int get_controller_data(struct controller_data_s *d, int port);
 
 void set_controller_data(int port, const struct controller_data_s *d);
+
+int get_controller_type(int port);
+
+void set_controller_type(int port, int type);
 
 void set_controller_rumble(int port, uint8_t l, uint8_t r);
 

--- a/libxenon/drivers/usb/usbdevs.c
+++ b/libxenon/drivers/usb/usbdevs.c
@@ -99,6 +99,8 @@ usb_drvlist_t usb_drivers[] = {
     {CLASS_ANY, 0x045e,0x2b0,   &dummy_driver}, // Kinect, not handled so we load a dummy drive
     {CLASS_ANY,	0x1bad,0xf900,	&usbctrl_driver}, // PDP Afterglow controller
     {CLASS_ANY,	0x045e,0x28f,	&dummy_driver}, // play and charge kit, not a controller - let's ignore it
+    {CLASS_ANY,	0x1430,0x4748,	&usbctrl_driver}, // Xplorer Guitar
+    {CLASS_ANY,	0x1bad,0x0002,	&usbctrl_driver}, // RB Guitar
 
     /*
      * Mass storage devices


### PR DESCRIPTION
This PR adds input APIs to get the "type" of the controller - a plastic guitar, racing wheel, dance mat etc - so if a game developer wanted to handle specific cases with these controllers, or a controller tester homebrew wanted display the different inputs provided by a given class of device, they could do that.

```c
int pad_type = get_controller_type(idx);
if (pad_type == CTRL_TYPE_GUITAR || pad_type == CTRL_TYPE_GUITAR_ALT)
   control_handler_for_guitar(idx, &ctrl);
else if (pad_type == CTRL_TYPE_GAMEPAD)
   control_handler_for_pad(idx, &ctrl);
```

For wireless controllers, the information is fetched out of the link report. This currently isn't fetched when the wireless adapter is detected, so only newly connected controllers are given a controller type.

For wired controllers, currently a hardcoded list of VID/PID pairs is used for guitars in particular. The information is reported in one of the descriptors (type 0x21) and ideally should be fetched from there. (We should also probably check for the XUSB descriptors on all connected devices to avoid needing a big VID/PID whitelist for every single controller that might exist like the Linux drivers have...)

When a controller is disconnected, the type is set to CTRL_TYPE_NONE to indicate being disconnected.