### PR TITLE
Use all threads to build the toolchain, allow thread count to be overridden

### DIFF
--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -5,7 +5,7 @@
 
 TARGET=xenon
 PREFIX="${PREFIX:-/usr/local/xenon}" # Install location of your final toolchain.
-PARALLEL=
+PARALLEL=${PARALLEL:--j$(nproc --all)}
 
 BINUTILS_DL="https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.gz"
 GCC_DL="https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz"


### PR DESCRIPTION
This pull request changes the behaviour of the PARALLEL environment variable, setting it to -j$(nproc --all) by default, and if the PARALLEL environment variable is already set by the user, uses that value instead.

Proposed fix for #46.