### PR TITLE
Add switch to try_rawflash to ignore image checks

### DIFF
--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -561,7 +561,7 @@ int try_rawflash(char *filename)
    return try_rawflash_internal(filename, false);
 }
 
-int try_rawflash_internal(char *filename, bool bIgnoreMetadataCheck)
+int try_rawflash_internal(char *filename, bool ignoreMetadataCheck)
 {
 	struct stat s;
 
@@ -577,7 +577,7 @@ int try_rawflash_internal(char *filename, bool bIgnoreMetadataCheck)
 
 	printf(" * rawflash v5 started (by cOz, modified By Swizzy)\n");
 
-   if(bIgnoreMetadataCheck)
+   if(ignoreMetadataCheck)
    {
       printf("\n" \
              " ! ****** Warning ******\n" \
@@ -608,7 +608,7 @@ int try_rawflash_internal(char *filename, bool bIgnoreMetadataCheck)
    {
       printf(" ! Bad Image for this console... ");
 
-      if(bIgnoreMetadataCheck)
+      if(ignoreMetadataCheck)
       {
          printf("rawflash_checkImage result ignored, flashing the image anyway...\n");
       }

--- a/libxenon/drivers/xenon_nand/xenon_sfcx.h
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.h
@@ -134,7 +134,7 @@ int sfcx_block_to_rawaddress(int block);
 int sfcx_rawaddress_to_block(int address);
 int rawflash_writeImage(int len, int f);
 int try_rawflash(char *filename);
-int try_rawflash_internal(char *filename, bool bIgnoreMetadataCheck);
+int try_rawflash_internal(char *filename, bool ignoreMetadataCheck);
 
 int sfcx_read_metadata_type(void);
 


### PR DESCRIPTION
In certain situations, we may need to flash images with metadata that does not match what is expected for the console.

e.g. when we build a DevGL image for an XSB console or build a Jasper image for a xenon with a Kronos GPU retrofit, rather than building an image to match the actual console type a Jasper 16mb image with Jasper-specific ECC is created. We can write this to the NAND fine with hardware tools and with simple 360 NAND flasher from the dashboard, but XeLL refuses to flash the image.
 
![IMG_2923](https://github.com/user-attachments/assets/63e6e984-346d-4e74-9e8e-642d27a83728)

This PR adds code to assist from the libxenon side by doing the following:

- Rename try_rawflash to try_rawflash_internal and add a flag that allows us to skip the verification step
- Add a wrapper around try_rawflash_internal so existing code that expects to be able to call with verification does not need to change

This will require a change on the XeLL side as well, but it does now allow flashing of images to DevGL consoles. I've tested on my xenon 0f and it works as expected, console boots XeLL and the dash after:

![IMG_2938](https://github.com/user-attachments/assets/26edd789-e25d-4710-a1c0-8f806180e118)
