### PR TITLE
Console type detection fixes

### DIFF
--- a/libxenon/drivers/xb360/xb360.c
+++ b/libxenon/drivers/xb360/xb360.c
@@ -513,7 +513,7 @@ int xenon_get_console_type()
 
 	if(PVR <= 0x710300) // DD3 or older CPU, must be a Xenon or Zephyr
 	{
-		if(DVE >= 0x11) // We've got HANA, this must be a zephyr
+		if(DVEversion >= 0x11) // We've got HANA, this must be a zephyr
 		{
 			return REV_ZEPHYR;
 		}


### PR DESCRIPTION
The console detection in xb360.c doesn't quite work right, especially for xenon and zephyr motherboards. The current state of the detection code will only return "xenon" if the CPU PVR is not 0x710200 or 0x710300 and a Y1 GPU is detected. Yet, Xenon and Zephyr both shipped with C1 (Y1) and C2(Y2, Rhea, Elpis) GPUs, and DD2/DD3 CPUs are fully compatible for swaps between xenon and zephyr.

In addition, even though it's not super common, Zeus and Kronos GPUs can be installed on falcon, zephyr, and xenon motherboards, so using the xenos ID for console detection isn't super reliable either.

We can save a function call and detect the console types correctly by checking the CPU PVR instead.

Each PVR implies one of two board types that the CPU was installed on:

- To tell Xenon/Zephyr apart, we can look at the DVE version.
- To tell Falcon and Jasper apart, we can look at the PCI bridge ID.
- To tell Trinity and Corona apart, the existing code looks at the DVE version (the PVR is the same for trinity and corona)
- Winchester is the only board to use Oban.
