### PR TITLE
AArch64 Host Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Dependencies for Linux distributions using the `dnf` or `apt` package managers w
 
 - flex
 - bison
-- gcc-multilib
+- gcc-multilib (if on x86\_64)
 - libgmp3-dev
 - libmpfr-dev
 - libmpc-dev

--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -12,7 +12,7 @@ GCC_DL="https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz"
 NEWLIB_DL="https://sourceware.org/pub/newlib/newlib-3.1.0.tar.gz"
 
 ZLIB_DL="https://zlib.net/fossils/zlib-1.2.11.tar.gz"
-LIBPNG_DL="https://download.sourceforge.net/libpng/libpng-1.5.10.tar.xz"
+LIBPNG_DL="https://download.sourceforge.net/libpng/libpng-1.5.30.tar.xz"
 BZIP2_DL="https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz"
 FREETYPE_DL="https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz"
 
@@ -435,9 +435,19 @@ if [ "$1" == "toolchain" ]; then
     fi
 
     if command -v apt-get &> /dev/null; then
-        sudo apt install -y build-essential flex bison gcc-multilib libgmp-dev libmpfr-dev libmpc-dev texinfo git wget
+        pkgs="build-essential flex bison libgmp-dev libmpfr-dev libmpc-dev texinfo git wget"
+        if [ "$(uname -m)" = "x86_64" ]; then
+            pkgs="$pkgs gcc-multilib"
+        fi
+        sudo apt install -y $pkgs || {
+            echo "Failed to install required packages!"
+            exit 1
+        }
     elif command -v dnf &> /dev/null; then
-        sudo dnf -y install gcc g++ flex bison glibc-devel.i686 libstdc++-devel.i686 gmp-devel mpfr-devel libmpc-devel texinfo git wget
+        sudo dnf -y install gcc g++ flex bison glibc-devel.i686 libstdc++-devel.i686 gmp-devel mpfr-devel libmpc-devel texinfo git wget || {
+            echo "Failed to install required packages!"
+            exit 1
+        }
     else
         echo "Info: a package manager was not detected. Ensure that the required dependencies have been installed."
     fi


### PR DESCRIPTION
Changes:
* Only install gcc-multilib on x86_64
* Make dependency installation failure fatal
* Bump libpng to latest release of 1.5.x branch
  * Bugfixes, and aarch64 host support, but should not break API
  * Bumping to 1.6.x (which'll have breaking API changes) is someone else's job :)


It's tested to build the toolchain+libraries, as well as XeLL properly on my 36GB M3 Pro MacBook Pro in a Debian aarch64 VM.
<img width="1284" height="812" alt="Screenshot_2026-02-07_at_2 38 08_PM" src="https://github.com/user-attachments/assets/3a5b1b87-53ca-4a4a-815d-f4f9d708832f" />

The build of XeLL also functions properly to the best of my testing, so it seems to produce functional code.
![IMG_0205](https://github.com/user-attachments/assets/008d6c45-65bc-4aa8-99c4-fddfa5200a66)


This PR does not address (due to lack of time/resources):
* AArch64 Fedora support
* Testing with additional libxenon-based applications

Fixes: #61 