### PR TITLE
ci: separate test job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,8 @@ on:
     branches: [ master ]
     paths-ignore: 
       - README.md
-  pull_request:
-    branches: [ master ]
-    paths-ignore: 
-      - README.md
+    tags:
+      - '*'
 
 jobs:
   build_toolchain:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test LibXenon
+
+on:
+  push:
+    paths-ignore: 
+      - README.md
+  pull_request:
+    paths-ignore: 
+      - README.md
+
+jobs:
+  test_libxenon:
+    runs-on: ubuntu-latest
+    container: free60/toolchain:latest
+    steps:
+      - name: Check Out Repo 
+        uses: actions/checkout@v6
+
+      - name: Compile and install libxenon
+        working-directory: toolchain/
+        run: ./build-xenon-toolchain libxenon
+
+      - name: Add toolchain to PATH
+        run: echo "/usr/local/xenon/bin" >> $GITHUB_PATH
+
+      - name: Build cube sample
+        working-directory: devkitxenon/examples/xenon/graphics/cube
+        env:
+          DEVKITXENON: /usr/local/xenon
+        run: |
+          make


### PR DESCRIPTION
So far all the PR failed testing (if they still build at least) as they require the organization-level-secrets, for logging into docker hub.
However, running this docker publish workflow every time on PRs does not make much sense and should only happen on the master-branch instead.

This PR adds a separate, minimalistic workflow that just pulls the latest toolchain image from DockerHub, installs libxenon and attempts to build the cube sample.

Obviously this does not test the correctness of the toolchain output nor does it test the toolchain installation.