### PR TITLE
Add device revision to the ATA device structure

### DIFF
--- a/libxenon/drivers/diskio/ata.c
+++ b/libxenon/drivers/diskio/ata.c
@@ -236,12 +236,13 @@ xenon_ata_dumpinfo(struct xenon_ata_device *dev, char *info) {
 	strncpy(text, data + 20, 20);
 	text[20] = 0;
 	printf("  * Serial: %s\n", text);
-	strncpy(text, data + 46, 8);
-	text[8] = 0;
-	printf("  * Firmware: %s\n", text);
-	strncpy(text, data + 54, 40);
-	text[40] = 0;
-	strncpy(dev->model, text, sizeof(dev->model));
+
+	strncpy(dev->rev, data + 46, 8);
+	dev->rev[8] = 0;
+	printf("  * Firmware: %s\n", dev->rev);
+
+	strncpy(dev->model, data + 54, 40);
+	dev->model[40] = 0;
 	printf("  * Model: %s\n", dev->model);
 
 	if (!dev->atapi) {
@@ -456,9 +457,13 @@ xenon_atapi_inquiry_model(struct xenon_ata_device *dev) {
 		return -1;
 	};
 
-	buf[8 + 24] = '\0';
-	strncpy(dev->model, &buf[8], sizeof(dev->model));
-	printf("ATAPI inquiry model: %s %d\n", dev->model);
+	memcpy(dev->model, &buf[8], 24);
+	dev->model[24] = '\0';
+
+	memcpy(dev->rev, &buf[32], 4);
+	dev->rev[4] = '\0';
+
+	printf("ATAPI inquiry model: %s %s\n", dev->model, dev->rev);
 
 	return 0;
 }

--- a/libxenon/drivers/diskio/ata.h
+++ b/libxenon/drivers/diskio/ata.h
@@ -82,6 +82,7 @@ extern "C" {
 		struct xenon_ata_dma_prd * prds;
 
 		char model[0x30];
+		char rev[9];
 	};
 
 	struct xenon_atapi_read {


### PR DESCRIPTION
ATA device structure currently stores the device model only. In addition, the `ATA inquiry model` print statement for the DVD drive does not print the firmware revision (currently, it prints a random decimal value due to an extra %d with no matching arg).

This PR adds `rev` to store the firmware revision of the ODD and HDD, populates that structure, and updates the printf statements to print the contents of the new struct. The extra %d has been removed.

The following is an example of what the output looks like, HDD there is no difference and for the ODD the drive revision is now properly printed 

![image](https://github.com/user-attachments/assets/c9eaa618-125f-4996-a17e-d0c95c6cfe37)