### PR TITLE
Updxell: check for XeLL after the second patch slot

### DIFF
--- a/libxenon/drivers/xb360/xb360.c
+++ b/libxenon/drivers/xb360/xb360.c
@@ -111,82 +111,82 @@ int cpu_get_key(unsigned char *data)
 
 int get_virtual_cpukey(unsigned char *data)
 {
-   unsigned char buffer[VFUSES_SIZE];
+	unsigned char buffer[VFUSES_SIZE];
 
-   uint32_t patchSlotOffset = 0;
-   uint32_t patchSlotSize = 0;
-   uint16_t patchSlotCount = 0;
+	uint32_t patchSlotOffset = 0;
+	uint32_t patchSlotSize = 0;
+	uint16_t patchSlotCount = 0;
 
-   const unsigned char fuseline0[0x8] = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+	const unsigned char fuseline0[0x8] = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
-   // JTAG virtual fuses must be checked manually, since they're not stored
-   // at the beginning of either of the patch slots like Glitch/DevGL images
-   if (xenon_get_logical_nand_data(&buffer, VFUSES_OFFSET, VFUSES_SIZE) == -1)
-   {
-      // Error reading NAND data
-      return 2;
-   }
+	// JTAG virtual fuses must be checked manually, since they're not stored
+	// at the beginning of either of the patch slots like Glitch/DevGL images
+	if (xenon_get_logical_nand_data(&buffer, VFUSES_OFFSET, VFUSES_SIZE) == -1)
+	{
+		// Error reading NAND data
+		return 2;
+	}
 
-   // Data was read from NAND, verify that it looks like a virtual fuse set
-   // by comparing it with what is expected for fuseline 0.
-   if( 0 == memcmp(buffer, fuseline0, sizeof(fuseline0)) )
-   {
-      memcpy(data,&buffer[0x20],0x10);
-      return 0;
-   }
+	// Data was read from NAND, verify that it looks like a virtual fuse set
+	// by comparing it with what is expected for fuseline 0.
+	if( 0 == memcmp(buffer, fuseline0, sizeof(fuseline0)) )
+	{
+		memcpy(data,&buffer[0x20],0x10);
+		return 0;
+	}
 
-   // If virtual fuses were not found at the JTAG offset, check the beginning of each patch slot.
-   // Patch slot offset, count, and size are stored at the beginning of NAND
+	// If virtual fuses were not found at the JTAG offset, check the beginning of each patch slot.
+	// Patch slot offset, count, and size are stored at the beginning of NAND
 
-   // Patch slot offset = DWORD at 0x64
-   if (xenon_get_logical_nand_data(&patchSlotOffset, 0x64, sizeof(patchSlotOffset)) == -1)
-   {
-      return 2;
-   }
+	// Patch slot offset = DWORD at 0x64
+	if (xenon_get_logical_nand_data(&patchSlotOffset, 0x64, sizeof(patchSlotOffset)) == -1)
+	{
+		return 2;
+	}
 
-   // Patch slot count  = WORD at 0x68
-   if (xenon_get_logical_nand_data(&patchSlotCount, 0x68, sizeof(patchSlotCount)) == -1)
-   {
-      return 2;
-   }
-   
-   // Patch slot size = DWORD at 0x70
-   if (xenon_get_logical_nand_data(&patchSlotSize, 0x70, sizeof(patchSlotSize)) == -1)
-   {
-      return 2;
-   }
+	// Patch slot count  = WORD at 0x68
+	if (xenon_get_logical_nand_data(&patchSlotCount, 0x68, sizeof(patchSlotCount)) == -1)
+	{
+		return 2;
+	}
 
-   // XeBuild has a bug where the patch slot size is set to zero for
-   // Falcon/Zephyr/Xenon DevGL and Glitch2m images. In this case, use
-   // the expected patch slot size of 0x10000 bytes.
-   if( 0 == patchSlotSize )
-   {
-      patchSlotSize = 0x10000;
-   }
+	// Patch slot size = DWORD at 0x70
+	if (xenon_get_logical_nand_data(&patchSlotSize, 0x70, sizeof(patchSlotSize)) == -1)
+	{
+		return 2;
+	}
 
-   // Check the beginning of each patch slot for a virtual fuse set
-   for(int i = 0; i < patchSlotCount; i++)
-   {
-      uint32_t patchSlotAddress = patchSlotOffset + (i * patchSlotSize);
+	// XeBuild has a bug where the patch slot size is set to zero for
+	// Falcon/Zephyr/Xenon DevGL and Glitch2m images. In this case, use
+	// the expected patch slot size of 0x10000 bytes.
+	if( 0 == patchSlotSize )
+	{
+		patchSlotSize = 0x10000;
+	}
 
-      // Read the virtual fuse set from NAND
-      if (xenon_get_logical_nand_data(&buffer, patchSlotAddress, VFUSES_SIZE) == -1)
-      {
-         return 2;
-      }
+	// Check the beginning of each patch slot for a virtual fuse set
+	for(int i = 0; i < patchSlotCount; i++)
+	{
+		uint32_t patchSlotAddress = patchSlotOffset + (i * patchSlotSize);
 
-      // Data was read from NAND, verify that it looks like a virtual fuse set
-      // by comparing it with what is expected for fuseline 0. If it doesn't
-      // match, the next patch slot will be checked.
-      if( 0 == memcmp(buffer, fuseline0, sizeof(fuseline0)) )
-      {
-         memcpy(data,&buffer[0x20],0x10);
-         return 0;
-      }
-   }
+		// Read the virtual fuse set from NAND
+		if (xenon_get_logical_nand_data(&buffer, patchSlotAddress, VFUSES_SIZE) == -1)
+		{
+			return 2;
+		}
 
-   // No virtual fuses found 
-   return 1;
+		// Data was read from NAND, verify that it looks like a virtual fuse set
+		// by comparing it with what is expected for fuseline 0. If it doesn't
+		// match, the next patch slot will be checked.
+		if( 0 == memcmp(buffer, fuseline0, sizeof(fuseline0)) )
+		{
+			memcpy(data,&buffer[0x20],0x10);
+			return 0;
+		}
+	}
+
+	// No virtual fuses found
+	return 1;
 }
 
 
@@ -212,10 +212,10 @@ int kv_read(unsigned char *data, int virtualcpukey)
 		return -1;
 
 	unsigned char cpu_key[0x10];
-        if (virtualcpukey)
-            get_virtual_cpukey(cpu_key);
-        else
-            cpu_get_key(cpu_key);
+		  if (virtualcpukey)
+				get_virtual_cpukey(cpu_key);
+		  else
+				cpu_get_key(cpu_key);
 	//print_key("kv_read: cpu key", cpu_key);
 
 	unsigned char hmac_key[0x10];
@@ -260,16 +260,16 @@ int kv_read(unsigned char *data, int virtualcpukey)
 	HMAC_SHA1_Done(&ctx);
 
 	int index = 0;
-    while (index < 0x10)
-    {
-    	if (data[index] != out[index])
-    	{
-    		// Hmm something is wrong, hmac is not matching
-    		//printf(" ! kv_read: kv hash check failed\n");
-    		return 2;
-    	}
-    	index += 1;
-    }
+	while (index < 0x10)
+	{
+		if (data[index] != out[index])
+		{
+			// Hmm something is wrong, hmac is not matching
+			//printf(" ! kv_read: kv hash check failed\n");
+			return 2;
+		}
+		index += 1;
+	}
 
 	return 0;
 }
@@ -393,7 +393,7 @@ void print_cpu_dvd_keys(void)
 		if (kv_get_cserial(cserial)==0)
 			print_cserial(" * Serial", cserial);
 	}
-		
+
 	printf("\n");
 }
 
@@ -403,23 +403,23 @@ void print_cpu_dvd_keys(void)
 //{
 //	int i, j, k, startblock, current, offsetinblock, blockcnt;
 //	unsigned char *user, *spare;
-//    
+//
 //    if (sfc.initialized != SFCX_INITIALIZED){
 //        printf(" ! sfcx is not initialized! Unable to update XeLL in NAND!\n");
 //		return -1;
 //    }
-//    
+//
 //    printf("\n * found XeLL update. press power NOW if you don't want to update.\n");
 //    delay(15);
-//    
+//
 //    for (k = 0; k < XELL_OFFSET_COUNT; k++)
 //    {
 //      current = xelloffsets[k];
 //      offsetinblock = current % sfc.block_sz;
 //      startblock = current/sfc.block_sz;
 //      blockcnt = offsetinblock ? (XELL_SIZE/sfc.block_sz)+1 : (XELL_SIZE/sfc.block_sz);
-//      
-//    
+//
+//
 //      spare = (unsigned char*)malloc(blockcnt*sfc.pages_in_block*sfc.meta_sz);
 //      if(!spare){
 //        printf(" ! Error while memallocating filebuffer (spare)\n");
@@ -431,7 +431,7 @@ void print_cpu_dvd_keys(void)
 //        return -1;
 //      }
 //      j = 0;
-//      unsigned char pagebuf[MAX_PAGE_SZ];	
+//      unsigned char pagebuf[MAX_PAGE_SZ];
 //
 //      for (i = (startblock*sfc.pages_in_block); i< (startblock+blockcnt)*sfc.pages_in_block; i++)
 //      {
@@ -441,10 +441,10 @@ void print_cpu_dvd_keys(void)
 //		memcpy(&spare[j*sfc.meta_sz],&pagebuf[sfc.page_sz],sfc.meta_sz);
 //		j++;
 //      }
-//      
+//
 //        if (memcmp(&user[offsetinblock+(XELL_FOOTER_OFFSET)],XELL_FOOTER,XELL_FOOTER_LENGTH) == 0){
 //            printf(" * XeLL Binary in NAND found @ 0x%08X\n", (startblock*sfc.block_sz)+offsetinblock);
-//         
+//
 //        memcpy(&user[offsetinblock], addr,len); //Copy over updxell.bin
 //        printf(" * Writing to NAND!\n");
 //		j = 0;
@@ -467,7 +467,7 @@ void print_cpu_dvd_keys(void)
 //        }
 //        printf(" * XeLL flashed! Reboot the xbox to enjoy the new build\n");
 //		for(;;);
-//	
+//
 //		}
 //	}
 //    printf(" ! Couldn't locate XeLL binary in NAND. Aborting!\n");
@@ -476,130 +476,175 @@ void print_cpu_dvd_keys(void)
 
 int updateXeLL(char *path)
 {
-    FILE *f;
-    int i, j, k, status, startblock, current, offsetinblock, blockcnt, filelength;
-    unsigned char *updxell, *user, *spare;
+	FILE *f;
+	int i, j, k, status, startblock, current, offsetinblock, blockcnt, filelength;
+	unsigned char *updxell, *user, *spare;
 	struct stat s;
 
   	memset(&s, 0, sizeof(struct stat));
 	stat(path, &s);
 	long size = s.st_size;
-	if (size <= 0)	
+	if (size <= 0)
 		return -1; //Invalid Filesize
-    
-    /* Check if updxell.bin is present */
-    f = fopen(path, "rb");
-    if (!f){
-        return -1; //Can't find/open updxell.bin
-    }
-    
-    if (sfc.initialized != SFCX_INITIALIZED){
-        fclose(f);
-        printf(" ! sfcx is not initialized! Unable to update XeLL in NAND!\n");
+
+	/* Check if updxell.bin is present */
+	f = fopen(path, "rb");
+	if (!f){
+		return -1; //Can't find/open updxell.bin
+	}
+
+	if (sfc.initialized != SFCX_INITIALIZED){
+		fclose(f);
+		printf(" ! sfcx is not initialized! Unable to update XeLL in NAND!\n");
+		return -1;
+	}
+
+	/* Check filesize of updxell.bin, only accept full 256kb binaries */
+	fseek(f, 0, SEEK_END);
+	filelength=ftell(f);
+	fseek(f, 0, SEEK_SET);
+	if (filelength != XELL_SIZE){
+		fclose(f);
+		printf(" ! %s does not have the correct size of 256kb. Aborting update!\n", path);
+		return -1;
+	}
+
+	printf("\n * found XeLL update. press power NOW if you don't want to update.\n");
+	delay(15);
+
+	for (k = 0; k < XELL_OFFSET_COUNT; k++)
+	{
+		if(xelloffsets[k] != 0x0)
+		{
+			// Try one of the known XeLL offsets
+			current = xelloffsets[k];
+		}
+		else
+		{
+			// If XeLL wasn't found at one of the known offsets,
+			// this is likely a 16 or 64mb XDK flash where XeLL
+			// is the first file in the flashfs, meaning it starts
+			// directly after the last patch slot
+
+			uint32_t patchSlotOffset = 0;
+			uint32_t patchSlotSize = 0;
+			uint16_t patchSlotCount = 0;
+
+			// Patch slot offset = DWORD at 0x64
+			if (xenon_get_logical_nand_data(&patchSlotOffset, 0x64, sizeof(patchSlotOffset)) == -1)
+			{
+				continue;
+			}
+
+			// Patch slot count  = WORD at 0x68
+			if (xenon_get_logical_nand_data(&patchSlotCount, 0x68, sizeof(patchSlotCount)) == -1)
+			{
+				continue;
+			}
+
+			// Patch slot size = DWORD at 0x70
+			if (xenon_get_logical_nand_data(&patchSlotSize, 0x70, sizeof(patchSlotSize)) == -1)
+			{
+				continue;
+			}
+
+			// XeBuild has a bug where the patch slot size is set to zero for
+			// Falcon/Zephyr/Xenon DevGL and Glitch2m images. In this case, use
+			// the expected patch slot size of 0x10000 bytes.
+			if( 0 == patchSlotSize )
+			{
+				patchSlotSize = 0x10000;
+			}
+
+			current = patchSlotOffset + (patchSlotSize * patchSlotCount);
+		}
+
+		offsetinblock = current % sfc.block_sz;
+		startblock = current/sfc.block_sz;
+		blockcnt = offsetinblock ? (XELL_SIZE/sfc.block_sz)+1 : (XELL_SIZE/sfc.block_sz);
+
+		spare = (unsigned char*)malloc(blockcnt*sfc.pages_in_block*sfc.meta_sz);
+		if(!spare){
+			printf(" ! Error while memallocating filebuffer (spare)\n");
+			return -1;
+		}
+		user = (unsigned char*)malloc(blockcnt*sfc.block_sz);
+		if(!user){
+		  printf(" ! Error while memallocating filebuffer (user)\n");
+		  return -1;
+		}
+		j = 0;
+		unsigned char pagebuf[MAX_PAGE_SZ];
+
+		for (i = (startblock*sfc.pages_in_block); i< (startblock+blockcnt)*sfc.pages_in_block; i++)
+		{
+			sfcx_read_page(pagebuf, (i*sfc.page_sz), 1);
+			//Split rawpage into user & spare
+			memcpy(&user[j*sfc.page_sz],pagebuf,sfc.page_sz);
+			memcpy(&spare[j*sfc.meta_sz],&pagebuf[sfc.page_sz],sfc.meta_sz);
+			j++;
+		}
+
+		if (memcmp(&user[offsetinblock+(XELL_FOOTER_OFFSET)],XELL_FOOTER,XELL_FOOTER_LENGTH) == 0){
+			printf(" * XeLL Binary in NAND found @ 0x%08X\n", (startblock*sfc.block_sz)+offsetinblock);
+
+			updxell = (unsigned char*)malloc(XELL_SIZE);
+			if(!updxell){
+				printf(" ! Error while memallocating filebuffer (updxell)\n");
+				return -1;
+			}
+
+			status = fread(updxell,1,XELL_SIZE,f);
+			if (status != XELL_SIZE){
+				fclose(f);
+				printf(" ! Error reading file from %s\n", path);
+				return -1;
+			}
+
+		 	if (memcmp(&updxell[XELL_FOOTER_OFFSET],XELL_FOOTER, XELL_FOOTER_LENGTH)){
+				printf(" ! XeLL does not seem to have matching footer, Aborting update!\n");
+				return -1;
+	 		}
+
+			fclose(f);
+			memcpy(&user[offsetinblock], updxell,XELL_SIZE); //Copy over updxell.bin
+			printf(" * Writing to NAND!\n");
+
+	 		j = 0;
+			for (i = startblock*sfc.pages_in_block; i < (startblock+blockcnt)*sfc.pages_in_block; i ++)
+			{
+		  		if (!(i%sfc.pages_in_block))
+					sfcx_erase_block(i*sfc.page_sz);
+
+		  		/* Copy user & spare data together in a single rawpage */
+				memcpy(pagebuf,&user[j*sfc.page_sz],sfc.page_sz);
+		  		memcpy(&pagebuf[sfc.page_sz],&spare[j*sfc.meta_sz],sfc.meta_sz);
+		  		j++;
+
+		  		if (!(sfcx_is_pageerased(pagebuf))) // We dont need to write to erased pages
+		  		{
+					memset(&pagebuf[sfc.page_sz+0x0C],0x0, 4); //zero only EDC bytes
+					sfcx_calcecc((unsigned int *)pagebuf); 	  //recalc EDC bytes
+					sfcx_write_page(pagebuf, i*sfc.page_sz);
+		  		}
+			}
+
+			printf(" * XeLL flashed! Reboot the xbox to enjoy the new build\n");
+	 		for(;;);
+		}
+	}
+
+	printf(" ! Couldn't locate XeLL binary in NAND. Aborting!\n");
 	return -1;
-    }
-   
-    /* Check filesize of updxell.bin, only accept full 256kb binaries */
-    fseek(f, 0, SEEK_END);
-    filelength=ftell(f);
-    fseek(f, 0, SEEK_SET);
-    if (filelength != XELL_SIZE){
-        fclose(f);
-        printf(" ! %s does not have the correct size of 256kb. Aborting update!\n", path);
-        return -1;
-    }
-    
-    printf("\n * found XeLL update. press power NOW if you don't want to update.\n");
-    delay(15);
-    
-    for (k = 0; k < XELL_OFFSET_COUNT; k++)
-    {
-      current = xelloffsets[k];
-      offsetinblock = current % sfc.block_sz;
-      startblock = current/sfc.block_sz;
-      blockcnt = offsetinblock ? (XELL_SIZE/sfc.block_sz)+1 : (XELL_SIZE/sfc.block_sz);
-      
-    
-      spare = (unsigned char*)malloc(blockcnt*sfc.pages_in_block*sfc.meta_sz);
-      if(!spare){
-        printf(" ! Error while memallocating filebuffer (spare)\n");
-        return -1;
-      }
-      user = (unsigned char*)malloc(blockcnt*sfc.block_sz);
-      if(!user){
-        printf(" ! Error while memallocating filebuffer (user)\n");
-        return -1;
-      }
-      j = 0;
-      unsigned char pagebuf[MAX_PAGE_SZ];	
-
-      for (i = (startblock*sfc.pages_in_block); i< (startblock+blockcnt)*sfc.pages_in_block; i++)
-      {
-         sfcx_read_page(pagebuf, (i*sfc.page_sz), 1);
-	 //Split rawpage into user & spare
-	 memcpy(&user[j*sfc.page_sz],pagebuf,sfc.page_sz);
-	 memcpy(&spare[j*sfc.meta_sz],&pagebuf[sfc.page_sz],sfc.meta_sz);
-	 j++;
-      }
-      
-        if (memcmp(&user[offsetinblock+(XELL_FOOTER_OFFSET)],XELL_FOOTER,XELL_FOOTER_LENGTH) == 0){
-            printf(" * XeLL Binary in NAND found @ 0x%08X\n", (startblock*sfc.block_sz)+offsetinblock);
-        
-         updxell = (unsigned char*)malloc(XELL_SIZE);
-         if(!updxell){
-           printf(" ! Error while memallocating filebuffer (updxell)\n");
-           return -1;
-         }
-        
-         status = fread(updxell,1,XELL_SIZE,f);
-         if (status != XELL_SIZE){
-           fclose(f);
-           printf(" ! Error reading file from %s\n", path);
-           return -1;
-         }
-		 
-		 if (memcmp(&updxell[XELL_FOOTER_OFFSET],XELL_FOOTER, XELL_FOOTER_LENGTH)){
-	   printf(" ! XeLL does not seem to have matching footer, Aborting update!\n");
-	   return -1;
-	 }
-         
-         fclose(f);
-         memcpy(&user[offsetinblock], updxell,XELL_SIZE); //Copy over updxell.bin
-         printf(" * Writing to NAND!\n");
-	 j = 0;
-         for (i = startblock*sfc.pages_in_block; i < (startblock+blockcnt)*sfc.pages_in_block; i ++)
-         {
-	     if (!(i%sfc.pages_in_block))
-		sfcx_erase_block(i*sfc.page_sz);
-
-	     /* Copy user & spare data together in a single rawpage */
-             memcpy(pagebuf,&user[j*sfc.page_sz],sfc.page_sz);
-	     memcpy(&pagebuf[sfc.page_sz],&spare[j*sfc.meta_sz],sfc.meta_sz);
-	     j++;
-
-	     if (!(sfcx_is_pageerased(pagebuf))) // We dont need to write to erased pages
-	     {
-             memset(&pagebuf[sfc.page_sz+0x0C],0x0, 4); //zero only EDC bytes
-             sfcx_calcecc((unsigned int *)pagebuf); 	  //recalc EDC bytes
-             sfcx_write_page(pagebuf, i*sfc.page_sz);
-	     }
-         }
-         printf(" * XeLL flashed! Reboot the xbox to enjoy the new build\n");
-	 for(;;);
-	
-      }
-    }
-    printf(" ! Couldn't locate XeLL binary in NAND. Aborting!\n");
-    return -1;
 }
 
 unsigned int xenon_get_DVE()
 {
 	unsigned int DVEversion, tmp;
 	xenon_smc_ana_read(0xfe, &DVEversion);
-    tmp = DVEversion;
-    tmp = (tmp & ~0xF0) | ((DVEversion >> 12) & 0xF0);
-    return (tmp & 0xFF);
+	tmp = DVEversion;
+	tmp = (tmp & ~0xF0) | ((DVEversion >> 12) & 0xF0);
+	return (tmp & 0xFF);
 }
 
 unsigned int xenon_get_PCIBridgeRevisionID()
@@ -622,7 +667,7 @@ unsigned int xenon_get_XenosID()
 int xenon_get_console_type()
 {
 	unsigned int PVR, PCIBridgeRevisionID, DVEversion;
-	 
+
 	PCIBridgeRevisionID = xenon_get_PCIBridgeRevisionID();
 	DVEversion = xenon_get_DVE();
 	PVR = xenon_get_CPU_PVR();
@@ -706,8 +751,8 @@ unsigned int xenon_get_kv_offset()
 
 unsigned int xenon_get_ram_size()
 {
-   // 0xE1040000 is the host bridge register where HWINIT stores a little endian uint32
-   // representing the amount of memory (in bytes) installed on the system. CB_B looks
-   // here to determine whether or not to throw panic 0xAF (UNSUPPORTED_RAM_SIZE)
+	// 0xE1040000 is the host bridge register where HWINIT stores a little endian uint32
+	// representing the amount of memory (in bytes) installed on the system. CB_B looks
+	// here to determine whether or not to throw panic 0xAF (UNSUPPORTED_RAM_SIZE)
 	return __builtin_bswap32(*(unsigned int *)0xE1040000);
 }

--- a/libxenon/drivers/xb360/xb360.h
+++ b/libxenon/drivers/xb360/xb360.h
@@ -80,15 +80,14 @@ unsigned int xenon_get_kv_offset();
 #define XELL_FOOTER_LENGTH 16
 #define XELL_FOOTER "xxxxxxxxxxxxxxxx"
 
-#define XELL_OFFSET_COUNT         8
+#define XELL_OFFSET_COUNT         7
 static const unsigned int xelloffsets[XELL_OFFSET_COUNT] = {0x70000, // ggBoot main xell-gggggg
 															0x95060,   // FreeBOOT Single-NAND main xell-2f
 															0x100000,  // XeLL-Only Image (Main)
 															0xC0000,   // XeLL-Only Image (Backup)
 															0xE0000,
-															0xF0000,   // DevGL/Glitch2m xell-gggggg in flashfs (16mb)
-															0xF4000,   // DevGL xell-gggggg in flashfs (64mb)
-															0xB80000}; // DevGL/Glitch2m xell-gggggg in flashfs (BB 256/512mb)
+															0xB80000,  // DevGL/Glitch2m xell-gggggg in flashfs (BB 256/512mb)
+															0x0};      // Special indicator: DevGL/Glitch2m xell-gggggg in flashfs for 16mb/64mb
 
 #define REV_XENON 0
 #define REV_ZEPHYR 1


### PR DESCRIPTION
This change calculates the location of xell as the first file in the flashfs if we don't find it at any of the other locations. This is where XeBuild puts XeLL when building an image with an XDK kernel. We can't hardcode this since it depends on the size of the kernel and bootloaders.

Also, to clean up xb360.c, this change does the following:
- correct inconsistent indentation
- remove trailing whitespace

I've tested this on my 64mb Xenon zero fuse, calculation behaves as expected and XeLL was successfully updated.